### PR TITLE
Nhse o34 orc.i14 startup

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,7 @@
   {riak_ensemble, {git, "https://github.com/OpenRiak/riak_ensemble", {branch, "openriak-3.2"}}},
   {pbkdf2, {git, "https://github.com/OpenRiak/erlang-pbkdf2.git", {branch, "openriak-3.2"}}},
   {cluster_info, {git, "https://github.com/OpenRiak/cluster_info.git", {branch, "openriak-3.2"}}},
-  {exometer_core, {git, "https://github.com/OpenRiak/exometer_core.git", {branch, "openriak-3.2"}}},
+  {exometer_core, {git, "https://github.com/OpenRiak/exometer_core.git", {branch, "openriak-3.4"}}},
   {basho_stats, {git, "https://github.com/OpenRiak/basho_stats.git", {branch, "openriak-3.2"}}}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -31,6 +31,6 @@
 
 {profiles, [
     {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [nowarn_export_all]}]},
-    {eqc, [{deps, [i{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
-    {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
+    {eqc,  [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
+    {gha,  [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
 {dialyzer, [{plt_apps, all_deps}]}.
 
 {profiles, [
-    {test, [{deps, [meck]}, {erl_opts, [nowarn_export_all]}]},
-    {eqc, [{deps, [meck]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [nowarn_export_all]}]},
+    {eqc, [{deps, [i{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -17,6 +17,8 @@
 -module(riak_core_ring_handler).
 -behaviour(gen_event).
 
+-include_lib("kernel/include/logger.hrl").
+
 %% gen_event callbacks
 -export([init/1, handle_event/2, handle_call/2,
          handle_info/2, terminate/2, code_change/3]).
@@ -59,6 +61,10 @@ code_change(_OldVsn, State, _Extra) ->
 %% ===================================================================
 
 ensure_vnodes_started(Ring) ->
+    ?LOG_INFO(
+        "Ring handler EVS due to ~0p",
+        [process_info(self(), current_stacktrace)]
+    ),
     case riak_core:vnode_modules() of
         [] ->
             ok;

--- a/src/riak_core_ring_handler.erl
+++ b/src/riak_core_ring_handler.erl
@@ -17,8 +17,6 @@
 -module(riak_core_ring_handler).
 -behaviour(gen_event).
 
--include_lib("kernel/include/logger.hrl").
-
 %% gen_event callbacks
 -export([init/1, handle_event/2, handle_call/2,
          handle_info/2, terminate/2, code_change/3]).
@@ -61,10 +59,6 @@ code_change(_OldVsn, State, _Extra) ->
 %% ===================================================================
 
 ensure_vnodes_started(Ring) ->
-    ?LOG_INFO(
-        "Ring handler EVS due to ~0p",
-        [process_info(self(), current_stacktrace)]
-    ),
     case riak_core:vnode_modules() of
         [] ->
             ok;

--- a/src/riak_core_ring_manager.erl
+++ b/src/riak_core_ring_manager.erl
@@ -227,8 +227,13 @@ is_stable_ring() ->
 force_update() ->
     ring_trans(
       fun(Ring, _) ->
-              NewRing = riak_core_ring:update_member_meta(node(), Ring, node(),
-                                                          unused, os:timestamp()), %% normally, should be a vclock.
+              NewRing = 
+                riak_core_ring:update_member_meta(
+                    node(),
+                    Ring, node(),
+                    unused,
+                    os:timestamp() %% normally, should be a vclock.
+                ),
               {new_ring, NewRing}
       end, []),
     ok.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -684,14 +684,29 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
 
     case {Owner, NextOwner, NewStatus, Status} of
         {_, _, invalid, _} ->
-            %% Handing off to invalid node, don't give-up data.
+            ?LOG_WARNING(
+                "Handoff of ~w complete to invalid node",
+                [Idx]
+            ),
             continue;
         {Prev, New, _, _} ->
+            ?LOG_INFO(
+                "Handoff of ~w complete to new owner and "
+                "future requests will be forwarded",
+                [Idx]
+            ),
             forward;
         {Prev, _, _, _} ->
-            %% Handoff wasn't to node that is scheduled in next, so no change.
+            ?LOG_INFO(
+                "Handoff of ~w complete to node which is not next owner",
+                [Idx]
+            ),
             continue;
         {_, _, _, _} ->
+            ?LOG_INFO(
+                "Handoff of ~w resulted in direct shutdown - ~w ~w ~w ~w",
+                [Idx, Owner, NextOwner, NewStatus, Status]
+            ),
             shutdown
     end.
 
@@ -721,10 +736,10 @@ finish_handoff(SeenIdxs, State=#state{mod=Mod,
             %% running on non-existant data.
             maybe_shutdown_pool(State),
             {DeleteTime, {ok, NewModState}} =
-                timer:tc(Mod, delete, [ModState], millisecond),
+                timer:tc(Mod, delete, [ModState]),
             ?LOG_INFO(
                 "~p ~p vnode finished handoff and deleted in ~w milliseconds",
-                [Idx, Mod, DeleteTime]
+                [Idx, Mod, DeleteTime div 1000]
             ),
             riak_core_vnode_manager:unregister_vnode(Idx, Mod),
             ?LOG_INFO(

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -653,25 +653,46 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
                         %% the ring structure in order to make gossip independent
                         %% of ring size.
                         ?LOG_INFO(
-                            "Updating local ring as handoff of ~w to "
+                            "Updating local ring as handoff of ~w ~w to "
                             "awaiting node ~w complete",
-                            [Idx, New]
+                            [Mod, Idx, New]
                         ),
                         {set_only, Ring2};
+                    {Prev, New, _, complete} ->
+                        ?LOG_DEBUG(
+                            "No ring transition for handoff of ~w ~w "
+                            "as handoffs already complete",
+                            [Mod, Idx]
+                        ),
+                        %% Assumption here is that this handoff has been
+                        %% triggered for a second time, so no update required
+                        %% to ring.
+                        %% This will happen continuously during handoffs in
+                        %% riak, due to riak_pipe_vnode hitting its inactivity
+                        %% timeout.  When it goes inactive this will trigger
+                        %% handoff - and the handoff will go straight to
+                        %% finish_handoff from start_handoff as the vnode
+                        %% is_empty - and so the handoff_manager is bypassed
+                        %% and there is no protection from duplicate passes
+                        %% through this loop.
+                        ignore;
                     {Owner, undefined, valid, undefined} when Owner =/= Prev ->
                         ?LOG_INFO(
-                            "No ring transition for handoff of ~w "
+                            "No ring transition for handoff of ~w ~w "
                             "as this node was not owner",
-                            [Idx]
+                            [Mod, Idx]
                         ),
                         ignore;
                     _ ->
                         ?LOG_INFO(
-                            "No ring transition for handoff of ~w "
+                            "No ring transition for handoff of ~w ~w "
                             "from owner ~w "
                             "where next owner is ~w and has status ~w "
                             "new owner is ~w and has status ~w",
-                            [Idx, Owner, NextOwner, Status, New, NewStatus]
+                            [
+                                Mod, Idx,
+                                Owner, NextOwner, Status, New, NewStatus
+                            ]
                         ),
                         ignore
                 end

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -634,26 +634,42 @@ mark_handoff_complete(SrcIdx, Target, SeenIdxs, Mod, resize) ->
     end;
 mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
     Prev = node(),
-    Result = riak_core_ring_manager:ring_trans(
-      fun(Ring, _) ->
-              Owner = riak_core_ring:index_owner(Ring, Idx),
-              {_, NextOwner, Status} = riak_core_ring:next_owner(Ring, Idx, Mod),
-              NewStatus = riak_core_ring:member_status(Ring, New),
+    Result =
+        riak_core_ring_manager:ring_trans(
+            fun(Ring, _) ->
+                Owner = riak_core_ring:index_owner(Ring, Idx),
+                {_, NextOwner, Status} =
+                    riak_core_ring:next_owner(Ring, Idx, Mod),
+                NewStatus = riak_core_ring:member_status(Ring, New),
 
-              case {Owner, NextOwner, NewStatus, Status} of
-                  {Prev, New, _, awaiting} ->
-                      Ring2 = riak_core_ring:handoff_complete(Ring, Idx, Mod),
-                      %% Optimization. Only alter the local ring without
-                      %% triggering a gossip, thus implicitly coalescing
-                      %% multiple vnode handoff completion events. In the
-                      %% future we should decouple vnode handoff state from
-                      %% the ring structure in order to make gossip independent
-                      %% of ring size.
-                      {set_only, Ring2};
-                  _ ->
-                      ignore
-              end
-      end, []),
+                case {Owner, NextOwner, NewStatus, Status} of
+                    {Prev, New, _, awaiting} ->
+                        Ring2 =
+                            riak_core_ring:handoff_complete(Ring, Idx, Mod),
+                        %% Optimization. Only alter the local ring without
+                        %% triggering a gossip, thus implicitly coalescing
+                        %% multiple vnode handoff completion events. In the
+                        %% future we should decouple vnode handoff state from
+                        %% the ring structure in order to make gossip independent
+                        %% of ring size.
+                        ?LOG_INFO(
+                            "Updating local ring as handoff for ~w to "
+                            "awaiting node ~w complete",
+                            [Idx, New]
+                        ),
+                        {set_only, Ring2};
+                    _ ->
+                        ?LOG_INFO(
+                            "No ring transition for handoff from owner ~w "
+                            "where next owner is ~w and has status ~w "
+                            "new owner is ~w and has status ~w",
+                            [Owner, NextOwner, Status, New, NewStatus]
+                        ),
+                        ignore
+                end
+            end,
+            []
+    ),
 
     case Result of
         {ok, NewRing} ->
@@ -704,12 +720,17 @@ finish_handoff(SeenIdxs, State=#state{mod=Mod,
             %% Shutdown the async pool beforehand, don't want callbacks
             %% running on non-existant data.
             maybe_shutdown_pool(State),
-            {ok, NewModState} = Mod:delete(ModState),
-            ?LOG_DEBUG("~p ~p vnode finished handoff and deleted.",
-                        [Idx, Mod]),
+            {DeleteTime, {ok, NewModState}} =
+                timer:tc(Mod, delete, [ModState], millisecond),
+            ?LOG_INFO(
+                "~p ~p vnode finished handoff and deleted in ~w milliseconds",
+                [Idx, Mod, DeleteTime]
+            ),
             riak_core_vnode_manager:unregister_vnode(Idx, Mod),
-            ?LOG_DEBUG("vnode hn/fwd :: ~p/~p :: ~p -> ~p~n",
-                        [State#state.mod, State#state.index, State#state.forward, HN]),
+            ?LOG_INFO(
+                "vnode hn/fwd :: ~p/~p :: ~p -> ~p",
+                [State#state.mod, State#state.index, State#state.forward, HN]
+            ),
             State2 = mod_set_forwarding(HN, State),
             continue(State2#state{modstate={deleted,NewModState}, % like to fail if used
                                   handoff_target=none,
@@ -867,7 +888,6 @@ handle_sync_event(core_status, _From, StateName, State=#state{index=Index,
 handle_info({'$vnode_proxy_ping', From, Ref, Msgs}, StateName, State) ->
     riak_core_vnode_proxy:cast(From, {vnode_proxy_pong, Ref, Msgs}),
     {next_state, StateName, State, State#state.inactivity_timeout};
-
 handle_info({'EXIT', Pid, Reason},
             _StateName,
             State=#state{mod=Mod,
@@ -878,31 +898,42 @@ handle_info({'EXIT', Pid, Reason},
         Reason when Reason == normal; Reason == shutdown ->
             continue(State#state{pool_pid=undefined});
         _ ->
-            ?LOG_ERROR("~p ~p worker pool crashed ~p\n", [Index, Mod, Reason]),
+            ?LOG_ERROR("~p ~p worker pool crashed ~p", [Index, Mod, Reason]),
             {pool, WorkerModule, PoolSize, WorkerArgs}=PoolConfig,
-            ?LOG_DEBUG("starting worker pool ~p with size "
-                        "of ~p for vnode ~p.",
-                        [WorkerModule, PoolSize, Index]),
+            ?LOG_DEBUG(
+                "starting worker pool ~p with size "
+                "of ~p for vnode ~p.",
+                [WorkerModule, PoolSize, Index]
+            ),
             {ok, NewPoolPid} =
-                riak_core_vnode_worker_pool:start_link(WorkerModule,
-                                                       PoolSize,
-                                                       Index,
-                                                       WorkerArgs,
-                                                       worker_props),
+                riak_core_vnode_worker_pool:start_link(
+                    WorkerModule,
+                    PoolSize,
+                    Index,
+                    WorkerArgs,
+                    worker_props
+                ),
             continue(State#state{pool_pid=NewPoolPid})
         end;
-
-handle_info({'DOWN',_Ref,process,_Pid,normal}, _StateName,
-            State=#state{modstate={deleted, _}}) ->
-    %% these messages are produced by riak_kv_vnode's aae tree
-    %% monitors; they are harmless, so don't yell about them. also
-    %% only dustbin them in the deleted modstate, because pipe vnodes
-    %% need them in other states
-    continue(State);
 handle_info(Info, _StateName,
-            State=#state{mod=Mod,modstate={deleted, _},index=Index}) ->
-    ?LOG_INFO("~p ~p ignored handle_info ~p - vnode unregistering\n",
-               [Index, Mod, Info]),
+        State=#state{mod=Mod,modstate={deleted, _},index=Index}) ->
+    case Info of
+        {'DOWN', _Ref, process, _Pid, normal} ->
+            %% these messages are produced by riak_kv_vnode's aae tree
+            %% monitors; they are harmless, so don't yell about them. also
+            %% only dustbin them in the deleted modstate, because pipe vnodes
+            %% need them in other states
+            ok;
+        {'EXIT', _Pid, normal} ->
+            %% For the leveled bookie these messages are produced by the store
+            %% exiting.
+            ok;
+        Info ->
+            ?LOG_INFO(
+                "~p ~p ignored handle_info ~p - vnode unregistering\n",
+            [Index, Mod, Info]
+            )
+    end,
     continue(State);
 handle_info({'EXIT', Pid, Reason}, StateName, State=#state{mod=Mod,modstate=ModState}) ->
     %% A linked processes has died so use the

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -245,9 +245,11 @@ do_init(State = #state{index=Index, mod=Mod, forward=Forward}) ->
             ModState0 = 
                 case lists:keyfind(pool, 1, Props) of
                     {pool, WorkerMod, PoolSize, WorkerArgs}=PoolConfig ->
-                        ?LOG_INFO("Starting vnode worker pool " ++ 
-                                        "~p with size of ~p~n",
-                                    [WorkerMod, PoolSize]),
+                        ?LOG_DEBUG(
+                            "Starting vnode worker pool " 
+                            "~p with size of ~p~n",
+                            [WorkerMod, PoolSize]
+                        ),
                         {ok, PoolPid} =
                             riak_core_vnode_worker_pool:start_link(WorkerMod,
                                                                 PoolSize,
@@ -258,8 +260,10 @@ do_init(State = #state{index=Index, mod=Mod, forward=Forward}) ->
                         % pool, it should export a function add_vnode_pool/2
                         case erlang:function_exported(Mod, add_vnode_pool, 2) of
                             true ->
-                                ?LOG_INFO("Adding vnode_pool ~w to ~w state",
-                                            [PoolPid, Mod]),
+                                ?LOG_DEBUG(
+                                    "Adding vnode_pool ~w to ~w state",
+                                    [PoolPid, Mod]
+                                ),
                                 Mod:add_vnode_pool(PoolPid, ModState);
                             false ->
                                 ModState

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -681,7 +681,7 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, HOType) ->
                         %% restarting once its handoff is complete.  However,
                         %% exclusions are per module when they are checked
                         %% they are compared with "disowning indices" which is
-                        %% not module specific.  So unitl all modules have
+                        %% not module specific.  So until all modules have
                         %% completed handoff for an index, and the claimant
                         %% has updated the ring to indicate the ownerhsip has
                         %% changed - the vnodes will continue to restart.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -653,17 +653,25 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
                         %% the ring structure in order to make gossip independent
                         %% of ring size.
                         ?LOG_INFO(
-                            "Updating local ring as handoff for ~w to "
+                            "Updating local ring as handoff of ~w to "
                             "awaiting node ~w complete",
                             [Idx, New]
                         ),
                         {set_only, Ring2};
+                    {Prev, undefined, valid, undefined} ->
+                        ?LOG_INFO(
+                            "No ring transition for handoff of ~w "
+                            "as next owner is undefined",
+                            [Idx]
+                        ),
+                        ignore;
                     _ ->
                         ?LOG_INFO(
-                            "No ring transition for handoff from owner ~w "
+                            "No ring transition for handoff of ~w "
+                            "from owner ~w "
                             "where next owner is ~w and has status ~w "
                             "new owner is ~w and has status ~w",
-                            [Owner, NextOwner, Status, New, NewStatus]
+                            [Idx, Owner, NextOwner, Status, New, NewStatus]
                         ),
                         ignore
                 end
@@ -685,26 +693,32 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
     case {Owner, NextOwner, NewStatus, Status} of
         {_, _, invalid, _} ->
             ?LOG_WARNING(
-                "Handoff of ~w complete to invalid node",
+                "Handoff of ~w complete to invalid node - continue",
                 [Idx]
             ),
             continue;
         {Prev, New, _, _} ->
             ?LOG_INFO(
-                "Handoff of ~w complete to new owner and "
-                "future requests will be forwarded",
+                "Handoff of ~w complete to new owner - forward",
                 [Idx]
             ),
             forward;
         {Prev, _, _, _} ->
             ?LOG_INFO(
-                "Handoff of ~w complete to node which is not next owner",
+                "Handoff of ~w complete to node which is not next owner "
+                "- continue",
                 [Idx]
             ),
             continue;
-        {_, _, _, _} ->
-            ?LOG_INFO(
-                "Handoff of ~w resulted in direct shutdown - ~w ~w ~w ~w",
+        {_, undefined, valid, undefined} ->
+            ?LOG_DEBUG(
+                "Non-ownerhsip handoff of ~w resulted in shutdown",
+                [Idx]
+            ),
+            shutdown;
+        _ ->
+            ?LOG_WARNING(
+                "Handoff of ~w resulted in shutdown - ~w ~w ~w ~w",
                 [Idx, Owner, NextOwner, NewStatus, Status]
             ),
             shutdown

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -632,7 +632,7 @@ mark_handoff_complete(SrcIdx, Target, SeenIdxs, Mod, resize) ->
         {ok, _NewRing} -> resize;
         _ -> continue
     end;
-mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
+mark_handoff_complete(Idx, {Idx, New}, [], Mod, HOType) ->
     Prev = node(),
     Result =
         riak_core_ring_manager:ring_trans(
@@ -640,10 +640,13 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
                 Owner = riak_core_ring:index_owner(Ring, Idx),
                 {_, NextOwner, Status} =
                     riak_core_ring:next_owner(Ring, Idx, Mod),
+                    % The status is the status with respect to this Mod only
+                    % i.e. it is complete if this Mod has already handed off -
+                    % other Mods may still need to handoff
                 NewStatus = riak_core_ring:member_status(Ring, New),
 
-                case {Owner, NextOwner, NewStatus, Status} of
-                    {Prev, New, _, awaiting} ->
+                case {Owner, NextOwner, NewStatus, Status, HOType} of
+                    {Prev, New, _, awaiting, _} ->
                         Ring2 =
                             riak_core_ring:handoff_complete(Ring, Idx, Mod),
                         %% Optimization. Only alter the local ring without
@@ -658,7 +661,7 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
                             [Mod, Idx, New]
                         ),
                         {set_only, Ring2};
-                    {Prev, New, _, complete} ->
+                    {Prev, New, _, complete, _} ->
                         ?LOG_DEBUG(
                             "No ring transition for handoff of ~w ~w "
                             "as handoffs already complete",
@@ -672,25 +675,35 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
                         %% timeout.  When it goes inactive this will trigger
                         %% handoff - and the handoff will go straight to
                         %% finish_handoff from start_handoff as the vnode
-                        %% is_empty - and so the handoff_manager is bypassed
-                        %% and there is no protection from duplicate passes
-                        %% through this loop.
+                        %% is_empty.
+                        %% The riak_core_handoff_manager has the concept of
+                        %% exclusions, which is intended to stop a vnode from
+                        %% restarting once its handoff is complete.  However,
+                        %% exclusions are per module when they are checked
+                        %% they are compared with "disowning indices" which is
+                        %% not module specific.  So unitl all modules have
+                        %% completed handoff for an index, and the claimant
+                        %% has updated the ring to indicate the ownerhsip has
+                        %% changed - the vnodes will continue to restart.
                         ignore;
-                    {Owner, undefined, valid, undefined} when Owner =/= Prev ->
-                        ?LOG_INFO(
+                    {Owner, undefined, valid, undefined, HOType}
+                            when Owner =/= Prev, HOType =/= ownership ->
+                        ?LOG_DEBUG(
                             "No ring transition for handoff of ~w ~w "
                             "as this node was not owner",
                             [Mod, Idx]
                         ),
+                        %% This is not an ownership handoff, so a ring
+                        %% transition would not be expected
                         ignore;
                     _ ->
                         ?LOG_INFO(
                             "No ring transition for handoff of ~w ~w "
-                            "from owner ~w "
+                            "of type ~w from owner ~w "
                             "where next owner is ~w and has status ~w "
                             "new owner is ~w and has status ~w",
                             [
-                                Mod, Idx,
+                                Mod, Idx, HOType,
                                 Owner, NextOwner, Status, New, NewStatus
                             ]
                         ),
@@ -714,33 +727,33 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
     case {Owner, NextOwner, NewStatus, Status} of
         {_, _, invalid, _} ->
             ?LOG_WARNING(
-                "Handoff of ~w complete to invalid node - continue",
-                [Idx]
+                "~w handoff of ~w ~w complete to invalid node - continue",
+                [HOType, Mod, Idx]
             ),
             continue;
         {Prev, New, _, _} ->
             ?LOG_INFO(
-                "Handoff of ~w complete to new owner - forward",
-                [Idx]
+                "Handoff of ~w ~w complete to new owner - forward",
+                [Mod, Idx]
             ),
             forward;
         {Prev, _, _, _} ->
             ?LOG_INFO(
-                "Handoff of ~w complete to node which is not next owner "
+                "Handoff of ~w ~w complete to node which is not next owner "
                 "- continue",
-                [Idx]
+                [Mod, Idx]
             ),
             continue;
         {_, undefined, valid, undefined} ->
             ?LOG_DEBUG(
-                "Non-ownerhsip handoff of ~w resulted in shutdown",
-                [Idx]
+                "Non-ownerhsip handoff of ~w ~w resulted in shutdown",
+                [Mod, Idx]
             ),
             shutdown;
         _ ->
             ?LOG_WARNING(
-                "Handoff of ~w resulted in shutdown - ~w ~w ~w ~w",
-                [Idx, Owner, NextOwner, NewStatus, Status]
+                "~w handoff of ~w ~w resulted in shutdown - ~w ~w ~w ~w",
+                [HOType, Mod, Idx, Owner, NextOwner, NewStatus, Status]
             ),
             shutdown
     end.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -658,10 +658,10 @@ mark_handoff_complete(Idx, {Idx, New}, [], Mod, _) ->
                             [Idx, New]
                         ),
                         {set_only, Ring2};
-                    {Prev, undefined, valid, undefined} ->
+                    {Owner, undefined, valid, undefined} when Owner =/= Prev ->
                         ?LOG_INFO(
                             "No ring transition for handoff of ~w "
-                            "as next owner is undefined",
+                            "as this node was not owner",
                             [Idx]
                         ),
                         ignore;
@@ -756,7 +756,7 @@ finish_handoff(SeenIdxs, State=#state{mod=Mod,
                 [Idx, Mod, DeleteTime div 1000]
             ),
             riak_core_vnode_manager:unregister_vnode(Idx, Mod),
-            ?LOG_INFO(
+            ?LOG_DEBUG(
                 "vnode hn/fwd :: ~p/~p :: ~p -> ~p",
                 [State#state.mod, State#state.index, State#state.forward, HN]
             ),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -637,7 +637,7 @@ get_vnode(IdxList, Mod, State) ->
                     [Pid, Idx]
                 ),
                 ok = riak_core_vnode:wait_for_init(Pid),
-                ?LOG_INFO("VNode initialization ready ~0p, ~0p ~w", [Pid, Idx, Mod]),
+                ?LOG_INFO("VNode initialization ready ~0p ~0p ~w", [Pid, Idx, Mod]),
                 {Idx, Pid}
         end,
     MaxStart =

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -654,7 +654,7 @@ get_vnode(IdxList, Mod, State) ->
                 IdxRec = #idxrec{key={Idx,Mod},idx=Idx,mod=Mod,pid=Pid,
                                 monref=MonRef},
                 MonRec = #monrec{monref=MonRef, key={Idx,Mod}},
-                ?LOG_INFO("Adding vnode rec ~w ~w", [Idx, Mod]),
+                ?LOG_DEBUG("Adding vnode rec ~w ~w", [Idx, Mod]),
                 add_vnode_rec([IdxRec, MonRec], State)
             end
             || Idx <- NotStarted

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -462,8 +462,15 @@ handle_info(management_tick, State0) ->
                 State2#state{repairs=[]}
         end,
 
-    MaxStart = app_helper:get_env(riak_core, vnode_rolling_start,
-                                  ?DEFAULT_VNODE_ROLLING_START),
+    MaxStart =
+        app_helper:get_env(
+            riak_core, 
+            vnode_rolling_start,
+            max(
+                ?DEFAULT_VNODE_ROLLING_START,
+                app_helper:get_env(riak_core, ring_creation_size, 64) div 4
+            )
+        ),
     State4 = State3#state{vnode_start_tokens=MaxStart},
     State5 = maybe_start_vnodes(Ring, State4),
 
@@ -620,17 +627,26 @@ get_vnode(IdxList, Mod, State) ->
     StartFun =
         fun(Idx) ->
                 ForwardTo = get_forward(Mod, Idx, State),
-                ?LOG_DEBUG("Will start VNode for partition ~p", [Idx]),
+                ?LOG_INFO("Will start VNode for partition ~0p ~w", [Idx, Mod]),
                 {ok, Pid} =
                     riak_core_vnode_sup:start_vnode(Mod, Idx, ForwardTo),
                 register_vnode_stats(Mod, Idx, Pid),
-                ?LOG_DEBUG("Started VNode, waiting for initialization to complete ~p, ~p ", [Pid, Idx]),
+                ?LOG_DEBUG(
+                    "Started VNode, "
+                    "waiting for initialization to complete ~0p, ~0p ",
+                    [Pid, Idx]
+                ),
                 ok = riak_core_vnode:wait_for_init(Pid),
-                ?LOG_DEBUG("VNode initialization ready ~p, ~p", [Pid, Idx]),
+                ?LOG_INFO("VNode initialization ready ~0p, ~0p ~w", [Pid, Idx, Mod]),
                 {Idx, Pid}
         end,
-    MaxStart = app_helper:get_env(riak_core, vnode_parallel_start,
-                                  ?DEFAULT_VNODE_ROLLING_START),
+    MaxStart =
+        app_helper:get_env(
+            riak_core, vnode_parallel_start, ?DEFAULT_VNODE_ROLLING_START),
+    ?LOG_INFO(
+        "Parallel starting ~w of ~w for ~w",
+        [MaxStart, length(NotStarted), Mod]
+    ),
     Pairs = Started ++ riak_core_util:pmap(StartFun, NotStarted, MaxStart),
     %% Return Pids in same order as input
     PairsDict = dict:from_list(Pairs),
@@ -881,17 +897,22 @@ update_never_started(Ring, State=#state{known_modules=KnownMods}) ->
             State;
         _ ->
             Indices = [Idx || {Idx, _} <- riak_core_ring:all_owners(Ring)],
-            lists:foldl(fun(Mod, StateAcc) ->
-                                update_never_started(Mod, Indices, StateAcc)
-                        end, State, UnknownMods)
+            MyIndices = riak_core_ring:my_indices(Ring),
+            lists:foldl(
+                fun(Mod, StateAcc) ->
+                    update_never_started(Mod, Indices, MyIndices, StateAcc)
+                end,
+                State,
+                UnknownMods
+            )
     end.
 
-update_never_started(Mod, Indices, State) ->
+update_never_started(Mod, Indices, MyIndices, State) ->
     IdxPids = get_all_index_pid(Mod, []),
     AlreadyStarted = [Idx || {Idx, _Pid} <- IdxPids],
-    NeverStarted = ordsets:subtract(ordsets:from_list(Indices),
-                                    ordsets:from_list(AlreadyStarted)),
-    NeverStarted2 = [{Idx, Mod} || Idx <- NeverStarted],
+    NeverStarted0 = lists:sort(lists:subtract(Indices, AlreadyStarted)),
+    NeverStarted1 = lists:subtract(NeverStarted0, MyIndices) ++ MyIndices, 
+    NeverStarted2 = [{Idx, Mod} || Idx <- NeverStarted1],
     NeverStarted3 = NeverStarted2 ++ State#state.never_started,
     KnownModules = [Mod | State#state.known_modules],
     State#state{known_modules=KnownModules, never_started=NeverStarted3}.

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -643,21 +643,22 @@ get_vnode(IdxList, Mod, State) ->
     MaxStart =
         app_helper:get_env(
             riak_core, vnode_parallel_start, ?DEFAULT_VNODE_ROLLING_START),
-    ?LOG_INFO(
-        "Parallel starting ~w of ~w for ~w",
-        [MaxStart, length(NotStarted), Mod]
-    ),
     Pairs = Started ++ riak_core_util:pmap(StartFun, NotStarted, MaxStart),
     %% Return Pids in same order as input
     PairsDict = dict:from_list(Pairs),
-    _ = [begin
-             Pid = dict:fetch(Idx, PairsDict),
-             MonRef = erlang:monitor(process, Pid),
-             IdxRec = #idxrec{key={Idx,Mod},idx=Idx,mod=Mod,pid=Pid,
-                              monref=MonRef},
-             MonRec = #monrec{monref=MonRef, key={Idx,Mod}},
-             add_vnode_rec([IdxRec, MonRec], State)
-         end || Idx <- NotStarted],
+    _ = 
+        [
+            begin
+                Pid = dict:fetch(Idx, PairsDict),
+                MonRef = erlang:monitor(process, Pid),
+                IdxRec = #idxrec{key={Idx,Mod},idx=Idx,mod=Mod,pid=Pid,
+                                monref=MonRef},
+                MonRec = #monrec{monref=MonRef, key={Idx,Mod}},
+                ?LOG_INFO("Adding vnode rec ~w ~w", [Idx, Mod]),
+                add_vnode_rec([IdxRec, MonRec], State)
+            end
+            || Idx <- NotStarted
+        ],
     [ dict:fetch(Idx, PairsDict) || Idx <- IdxList].
 
 
@@ -907,15 +908,24 @@ update_never_started(Ring, State=#state{known_modules=KnownMods}) ->
             )
     end.
 
-update_never_started(Mod, Indices, MyIndices, State) ->
+update_never_started(Mod, IndicesL, MyIndicesL, State) ->
     IdxPids = get_all_index_pid(Mod, []),
-    AlreadyStarted = [Idx || {Idx, _Pid} <- IdxPids],
-    NeverStarted0 = lists:sort(lists:subtract(Indices, AlreadyStarted)),
-    NeverStarted1 = lists:subtract(NeverStarted0, MyIndices) ++ MyIndices, 
-    NeverStarted2 = [{Idx, Mod} || Idx <- NeverStarted1],
-    NeverStarted3 = NeverStarted2 ++ State#state.never_started,
+    AlreadyStartedS =
+        sets:from_list([Idx || {Idx, _Pid} <- IdxPids], [{version, 2}]),
+    MyIndicesS = sets:from_list(MyIndicesL, [{version, 2}]),
+    AllIndicesS = sets:from_list(IndicesL, [{version, 2}]),
+    NotMyIndicesS = sets:subtract(AllIndicesS, MyIndicesS),
+    NeverStarted =
+        sets:to_list(sets:subtract(NotMyIndicesS, AlreadyStartedS))
+        ++ sets:to_list(sets:subtract(MyIndicesS, AlreadyStartedS)),
+    NeverStarted1 = [{Idx, Mod} || Idx <- NeverStarted],
+    NeverStarted2 = NeverStarted1 ++ State#state.never_started,
+    ?LOG_INFO(
+        "Update never started for Mod ~w with count ~w to be added to ~w",
+        [Mod, length(NeverStarted1), length(State#state.never_started)]
+    ),
     KnownModules = [Mod | State#state.known_modules],
-    State#state{known_modules=KnownModules, never_started=NeverStarted3}.
+    State#state{known_modules=KnownModules, never_started=NeverStarted2}.
 
 maybe_start_vnodes(Ring, State) ->
     case riak_core_ring:check_lastgasp(Ring) of


### PR DESCRIPTION
See https://github.com/OpenRiak/riak_core/issues/8

This changes the riak_core_vnode update_never_started so that it prefers to start vnodes that are not owned by this node within the ring.  These vnodes will start in series - so this makes it more likely that vnodes owned (and containing data) will start in parallel.

Changes logging so that we log the starting of the vnode, not of the vnode worker pool.

Further logging of the handoff completion process has been added.  This is as a result of https://github.com/OpenRiak/riak_kv/issues/23 - an issue which is not currently resolvable due to a lack of log information about what is occurring at handoff completion