### PR TITLE
Add control of cluster_transfer_limit

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -45,10 +45,27 @@
 %% low value for the handoff_batch_threshold_count (e.g. 200), then raise the
 %% handoff_timeout.  Further, if using the leveled backend in Riak KV
 %% investigate raising the the backend_pause.
+%% Note that there is an additional cluster_transfer_limit configuration option
+%% which may prevent this limit from being reached.
 {mapping, "transfer_limit", "riak_core.handoff_concurrency", [
   {datatype, integer},
   {default, 2},
   {commented, 2}
+]}.
+
+%% @doc Number of concurrent cluster-wide prompted transfers allowed.
+%% Ownership handoffs may be prompted by vnode inactivity, or by the vnode
+%% manager's scheduled tick activity.  Should the vnodes never become inactive
+%% only the manager will prompt, and this configuration option acts as a
+%% cluster-wide limit on concurrent handoffs prompted by the management tick.
+%% Unless the current number of ongoing, or blocked, handoffs is below this
+%% limit in the cluster (regardless of the prompt for the handoff), the
+%% management tick on all nodes will be blocked from prompting further
+%% transfers.
+{mapping, "cluster_transfer_limit", "riak_core.forced_ownership_handoff", [
+  {datatype, integer},
+  {default, 8},
+  {commented, 8}
 ]}.
 
 %% @doc Handoff batch threshold count

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
 {dialyzer, [{plt_apps, all_deps}]}.
 
 {profiles, [
-    {test, [{deps, [meck]}, {erl_opts, [nowarn_export_all]}]},
-    {eqc, [{deps, [meck]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [nowarn_export_all]}]},
+    {eqc, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.


### PR DESCRIPTION
The forced_ownerhsip_handoff was a previously undocumented limit to transfers.  This adds it to the standard configuration.