### PR TITLE
Fix off-by-one error with size of hash space

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
 {dialyzer, [{plt_apps, all_deps}]}.
 
 {profiles, [
-    {test, [{deps, [meck]}, {erl_opts, [nowarn_export_all]}]},
-    {eqc, [{deps, [meck]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
-    {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [nowarn_export_all]}]},
+    {eqc,  [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
+    {gha,  [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.

--- a/src/chash.erl
+++ b/src/chash.erl
@@ -52,7 +52,9 @@
 
 -export_type([chash/0, index/0, index_as_int/0]).
     
--define(RINGTOP, trunc(math:pow(2,160)-1)).  % SHA-1 space
+-define(RINGTOP, (1 bsl 160)).
+    % SHA-1 space 0 to (2 ^ 160) - 1
+    % ?RINGTOP is size of this space i.e. 2 ^ 160
 
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").


### PR DESCRIPTION
As the previous code used truncated floats to calculate, and the the numbers are bigger than 2 ^ 53, the off-by-one error never mattered due to approximation:

i.e.

```erlang
1> trunc(math:pow(2, 160) - 1) == trunc(math:pow(2,160)).
true
```

But relying on this is confusing.