### PR TITLE
Nhse o34 orkv.i61 repairoptions

### DIFF
--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -20,11 +20,11 @@
 -type predicate() :: fun((any()) -> boolean()).
 
 -type index() :: chash:index_as_int().
--type mod_src_tgt() :: {module(), index(), index()} | {undefined, undefined, undefined}.
+-type mod_src_tgt() :: {module(), index(), index()}.
 -type mod_partition() :: {module(), index()}.
 
 -record(handoff_status,
-        { mod_src_tgt           :: mod_src_tgt(),
+        { mod_src_tgt           :: mod_src_tgt()|undefined,
           src_node              :: node(),
           target_node           :: node(),
           direction             :: inbound | outbound,

--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -37,6 +37,26 @@
   Size >= 8
  end}.
 
+%% @doc span of vnodes to be involved in repair.
+%% Minimum requirement is for a pair of vnodes, but when nval is set to 3 or
+%% higher, a double_pair can be requested - and 4 nodes will be asked to
+%% contribute to each repair.
+%% Within repair negative filters are used so that overlapping sources for the
+%% repair will not pass the same key through their handoff filter function. 
+%% This avoids double-sending, but not any work done by the backend fold to
+%% return the object.
+%% In Riak KV double_pair should only be used with the repair_deferred option,
+%% so that filtered keys avoid a fetch (as the fetch is deferred until after
+%% after the filter has been passed).  Without support (the leveled backend is
+%% required) and configuration of this option, increasing the repair span will
+%% still lead to the majority of effort in repair being duplicated, despite the
+%% use of negative filters.
+{mapping, "repair_span", "riak_core.repair_span", [
+  {datatype, {enum, [pair, double_pair]}},
+  {default, pair},
+  {commented, pair}
+]}.
+
 %% @doc Number of concurrent node-to-node transfers allowed.
 %% It is generally safe to raise this number to increase concurrency.  A
 %% common value to use would be 8.  However, it is necessary to monitor for

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
   {poolboy, {git, "https://github.com/OpenRiak/poolboy.git", {branch, "openriak-3.2"}}},
   {riak_sysmon, {git, "https://github.com/OpenRiak/riak_sysmon.git", {branch, "openriak-3.2"}}},
   {clique, {git, "https://github.com/OpenRiak/clique.git", {branch, "openriak-3.2"}}},
-  {eleveldb, {git, "https://github.com/OpenRiak/eleveldb.git", {branch, "openriak-3.2"}}},
+  {eleveldb, {git, "https://github.com/OpenRiak/eleveldb.git", {branch, "nhse-o32-oeldb.i1-bumpsnappy"}}},
   {riak_ensemble, {git, "https://github.com/OpenRiak/riak_ensemble", {branch, "openriak-3.2"}}},
   {pbkdf2, {git, "https://github.com/OpenRiak/erlang-pbkdf2.git", {branch, "openriak-3.2"}}},
   {cluster_info, {git, "https://github.com/OpenRiak/cluster_info.git", {branch, "openriak-3.2"}}},

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
 {dialyzer, [{plt_apps, all_deps}]}.
 
 {profiles, [
-    {test, [{deps, [meck]}, {erl_opts, [nowarn_export_all]}]},
-    {eqc, [{deps, [meck]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [nowarn_export_all]}]},
+    {eqc, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.

--- a/rebar.config
+++ b/rebar.config
@@ -19,7 +19,7 @@
   {poolboy, {git, "https://github.com/OpenRiak/poolboy.git", {branch, "openriak-3.2"}}},
   {riak_sysmon, {git, "https://github.com/OpenRiak/riak_sysmon.git", {branch, "openriak-3.2"}}},
   {clique, {git, "https://github.com/OpenRiak/clique.git", {branch, "openriak-3.2"}}},
-  {eleveldb, {git, "https://github.com/OpenRiak/eleveldb.git", {branch, "nhse-o32-oeldb.i1-bumpsnappy"}}},
+  {eleveldb, {git, "https://github.com/OpenRiak/eleveldb.git", {branch, "openriak-3.2"}}},
   {riak_ensemble, {git, "https://github.com/OpenRiak/riak_ensemble", {branch, "openriak-3.2"}}},
   {pbkdf2, {git, "https://github.com/OpenRiak/erlang-pbkdf2.git", {branch, "openriak-3.2"}}},
   {cluster_info, {git, "https://github.com/OpenRiak/cluster_info.git", {branch, "openriak-3.2"}}},

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -286,10 +286,11 @@ handle_cast({kill_xfer, ModSrcTarget, Reason}, State) ->
 handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
     case lists:keytake(Ref, #handoff_status.transport_mon, HS) of
         {value,
-         #handoff_status{mod_src_tgt={M, S, I}, direction=Dir, vnode_pid=Vnode,
+         #handoff_status{mod_src_tgt=ModSrcTarget, direction=Dir, vnode_pid=Vnode,
                          vnode_mon=VnodeM, req_origin=Origin},
          NewHS
         } ->
+            {M, S, I} = expand_mod_source_target(ModSrcTarget),
             WarnVnode =
                 case Reason of
                     %% if the reason the handoff process died was anything other
@@ -334,9 +335,10 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
         false ->
             case lists:keytake(Ref, #handoff_status.vnode_mon, HS) of
                 {value,
-                 #handoff_status{mod_src_tgt={M,_,I}, direction=Dir,
+                 #handoff_status{mod_src_tgt=ModSrcTarget, direction=Dir,
                                  transport_pid=Trans, transport_mon=TransM},
                  NewHS} ->
+                    {M, _, I} = expand_mod_source_target(ModSrcTarget),
                     %% In this case the vnode died and the handoff
                     %% sender must be killed.
                     ?LOG_ERROR("An ~w handoff of partition ~w ~w was "
@@ -363,8 +365,18 @@ code_change(_OldVsn, State, _Extra) ->
 %%% Private
 %%%===================================================================
 
+-ifdef(TEST).
+expand_mod_source_target(undefined) ->
+    {undefined, undefined, undefined};
+expand_mod_source_target(ModSourceTarget) ->
+    ModSourceTarget.
+-else.
+expand_mod_source_target(ModSourceTarget) ->
+    ModSourceTarget.
+-endif.
+
 build_status(HO) ->
-    #handoff_status{mod_src_tgt={Mod, SrcP, TargetP},
+    #handoff_status{mod_src_tgt=ModSrcTarget,
                     src_node=SrcNode,
                     target_node=TargetNode,
                     direction=Dir,
@@ -372,6 +384,7 @@ build_status(HO) ->
                     timestamp=StartTS,
                     transport_pid=TPid,
                     type=Type}=HO,
+    {Mod, SrcP, TargetP} = expand_mod_source_target(ModSrcTarget),
     {status_v2, [{mod, Mod},
                  {src_partition, SrcP},
                  {target_partition, TargetP},
@@ -522,34 +535,40 @@ send_handoff(HOType, {Mod, Src, Target}, Node, Vnode, HS, {Filter, FilterModFun}
                             HOAcc0 = undefined,
                             HONotSentFun = undefined
                     end,
-                    HOOpts = [{filter, HOFilter},
-                              {notsent_acc0, HOAcc0},
-                              {notsent_fun, HONotSentFun} | BaseOpts],
-                    {ok, Pid} = riak_core_handoff_sender_sup:start_sender(HOType,
-                                                                          Mod,
-                                                                          Node,
-                                                                          Vnode,
-                                                                          HOOpts),
+                    HOOpts =
+                        [
+                            {filter, HOFilter},
+                            {notsent_acc0, HOAcc0},
+                            {notsent_fun, HONotSentFun},
+                            {origin, Origin}
+                        ] ++
+                        BaseOpts,
+                    {ok, Pid} =
+                        riak_core_handoff_sender_sup:start_sender(
+                            HOType, Mod, Node, Vnode, HOOpts),
                     PidM = monitor(process, Pid),
                     Size = validate_size(proplists:get_value(size, Opts)),
 
                     %% successfully started up a new sender handoff
-                    {ok, #handoff_status{ transport_pid=Pid,
-                                          transport_mon=PidM,
-                                          direction=outbound,
-                                          timestamp=os:timestamp(),
-                                          src_node=node(),
-                                          target_node=Node,
-                                          mod_src_tgt={Mod, Src, Target},
-                                          vnode_pid=Vnode,
-                                          vnode_mon=VnodeM,
-                                          status=[],
-                                          stats=dict:new(),
-                                          type=HOType,
-                                          req_origin=Origin,
-                                          filter_mod_fun=FilterModFun,
-                                          size=Size
-                                        }
+                    {
+                        ok, 
+                        #handoff_status{
+                            transport_pid=Pid,
+                            transport_mon=PidM,
+                            direction=outbound,
+                            timestamp=os:timestamp(),
+                            src_node=node(),
+                            target_node=Node,
+                            mod_src_tgt={Mod, Src, Target},
+                            vnode_pid=Vnode,
+                            vnode_mon=VnodeM,
+                            status=[],
+                            stats=dict:new(),
+                            type=HOType,
+                            req_origin=Origin,
+                            filter_mod_fun=FilterModFun,
+                            size=Size
+                        }
                     };
 
                 %% handoff already going, just return it
@@ -572,7 +591,6 @@ receive_handoff (SSLOpts) ->
                                   transport_mon=PidM,
                                   direction=inbound,
                                   timestamp=os:timestamp(),
-                                  mod_src_tgt={undefined, undefined, undefined},
                                   src_node=undefined,
                                   target_node=undefined,
                                   status=[],

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -300,10 +300,26 @@ handle_info({'DOWN', Ref, process, _Pid, Reason}, State=#state{handoffs=HS}) ->
                     X when X == max_concurrency orelse
                            (element(1, X) == shutdown andalso
                             element(2, X) == max_concurrency) ->
-                        ?LOG_INFO("An ~w handoff of partition ~w ~w was terminated for reason: ~w~n", [Dir,M,I,Reason]),
+                        ShouldILog =
+                        application:get_env(
+                            riak_core, handoff_log_max_concurrency, false),
+                        case ShouldILog of
+                            true ->
+                                ?LOG_INFO(
+                                    "An ~w handoff of partition ~w ~w "
+                                    "was terminated for reason: ~w",
+                                    [Dir, M, I, Reason]
+                                );
+                            false ->
+                                ok
+                        end,
                         true;
                     _ ->
-                        ?LOG_ERROR("An ~w handoff of partition ~w ~w was terminated for reason: ~w~n", [Dir,M,I,Reason]),
+                        ?LOG_ERROR(
+                            "An ~w handoff of partition ~w ~w "
+                            "was terminated for reason: ~w",
+                            [Dir, M, I, Reason]
+                        ),
                         true
                 end,
 

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -253,8 +253,8 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                                             fun(F) -> not F(K) end,
                                             NegativeFilters
                                         );
-                                    NotTrue ->
-                                        NotTrue
+                                    false ->
+                                        false
                                 end
                             end
                     end;

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -51,12 +51,17 @@
                     [Type, Module, SrcNode, SrcPartition, TargetNode,
                      TargetPartition] ++ Args)).
 
+-type filter_fun() :: fun((term()) -> boolean()).
+-type encoder_fun() :: fun((term(), term()) -> corrupted|ignore|binary()).
+
+
 %% Accumulator for the visit item HOF
 -record(ho_acc,
         {
           ack                  :: non_neg_integer(),
           error                :: ok | {error, any()},
-          filter               :: function(),
+          filter               :: filter_fun(),
+          encoder              :: encoder_fun(),
           module               :: module(),
           parent               :: pid(),
           socket               :: any(),
@@ -118,9 +123,17 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
 
     try
         %% Give workers one more chance to abort or get a lock or whatever.
-        FoldOpts = maybe_call_handoff_started(Module, SrcPartition),
+        %% Also can pass options {[OptKey, OptVal}] or a list of
+        %% [{OptKey, OptVal}] options specific to one type of handoff using:
+        %% {HandoffType, [{OptKey, OptVal}]}
+        FoldOpts =
+            filter_foldopts(
+                Type,
+                maybe_call_handoff_started(Module, SrcPartition)
+            ),
 
         Filter = get_filter(Opts),
+        Encoder = get_encoder(Module, Type, {TargetNode, TargetPartition}),
         [_Name,Host] = string:tokens(atom_to_list(TargetNode), "@"),
         {ok, Port} = get_handoff_port(TargetNode),
         TNHandoffIP =
@@ -159,6 +172,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                 ack=0,
                 error=ok,
                 filter=Filter,
+                encoder=Encoder,
                 module=Module,
                 parent=ParentPid,
                 socket=Socket,
@@ -325,6 +339,22 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
              gen_fsm:send_event(ParentPid, {handoff_error, Class, Reason})
      end.
 
+-spec filter_foldopts(ho_type(), proplists:proplist()) -> proplists:proplist().
+filter_foldopts(HoType, FoldOpts) ->
+    filter_foldopts(HoType, FoldOpts, []).
+
+filter_foldopts(_HoType, [], FilteredOps) ->
+    FilteredOps;
+filter_foldopts(HoType, [{HoType, TypeOpts}|Rest], FilteredOpts)
+        when is_list(TypeOpts) ->
+    filter_foldopts(HoType, Rest,[TypeOpts] ++ FilteredOpts);
+filter_foldopts(HoType, [{_AltHoType, TypeOpts}|Rest], FilteredOpts)
+        when is_list(TypeOpts) ->
+    filter_foldopts(HoType, Rest, FilteredOpts);
+filter_foldopts(HoType, [{OptKey, OptVal}|Rest], FilteredOpts) ->
+    filter_foldopts(HoType, Rest, [{OptKey, OptVal}|FilteredOpts]).
+
+
 -spec set_timeouts_and_thresholds(ho_acc()) -> ho_acc().
 set_timeouts_and_thresholds(HoAcc) ->
     RecvTimeout = get_handoff_timeout(),
@@ -366,7 +396,7 @@ set_timeouts_and_thresholds(HoAcc) ->
 visit_item(K, V, Acc0) ->
     Acc = maybe_keepalive_receiver(Acc0),
     #ho_acc{filter=Filter,
-            module=Module,
+            encoder=Encoder,
             total_objects=TotalObjects,
             item_queue=ItemQueue,
             item_queue_length=ItemQueueLength,
@@ -377,11 +407,13 @@ visit_item(K, V, Acc0) ->
             notsent_acc=NotSentAcc} = Acc,
     case Filter(K) of
         true ->
-            case Module:encode_handoff_item(K, V) of
+            case Encoder(K, V) of
                 corrupted ->
                     {Bucket, Key} = K,
                     ?LOG_WARNING(
                         "Unreadable object ~p/~p discarded", [Bucket, Key]),
+                    Acc;
+                ignore ->
                     Acc;
                 BinObj ->
                     ItemQueue2 = [BinObj | ItemQueue],
@@ -695,6 +727,15 @@ get_filter(Opts) ->
     case proplists:get_value(filter, Opts) of
         none -> fun(_) -> true end;
         Filter -> Filter
+    end.
+
+-spec get_encoder(module(), ho_type(), {node(), integer()}) -> encoder_fun().
+get_encoder(Module, Type, Target) ->
+    case lists:member({handoff_encoding_fun, 2}, Module:module_info(exports)) of
+        true ->
+            Module:handoff_encoding_fun(Type, Target);
+        _ ->
+            fun Module:encode_handoff_item/2
     end.
 
 -spec send_sync(

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -233,6 +233,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                         ),
                     case NegativeFilters of
                         ok ->
+                            put(last_hash, no_cache),
                             Filter;
                         NegativeFilters when is_list(NegativeFilters) ->
                             ?LOG_INFO(

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -347,7 +347,7 @@ filter_foldopts(_HoType, [], FilteredOps) ->
     FilteredOps;
 filter_foldopts(HoType, [{HoType, TypeOpts}|Rest], FilteredOpts)
         when is_list(TypeOpts) ->
-    filter_foldopts(HoType, Rest,[TypeOpts] ++ FilteredOpts);
+    filter_foldopts(HoType, Rest, TypeOpts ++ FilteredOpts);
 filter_foldopts(HoType, [{_AltHoType, TypeOpts}|Rest], FilteredOpts)
         when is_list(TypeOpts) ->
     filter_foldopts(HoType, Rest, FilteredOpts);

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -306,7 +306,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
             total_bytes=TotalBytes,
             filtered_objects = SkippedObjs,
             item_queue_length = LastBatchLength,
-            item_queue_byte_size = LastBatchSize,
+            item_queue_byte_size = LastBatchByteSize,
             notsent_acc=NotSentAcc,
             rcv_timeout=RecvTimeout} = AccRecord,
 
@@ -341,7 +341,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
 
                 FoldTimeDiff = end_fold_time(StartFoldTime),
                 ThroughputBytes =
-                    (TotalBytes + LastBatchSize)/FoldTimeDiff,
+                    (TotalBytes + LastBatchByteSize)/FoldTimeDiff,
 
                 ok = 
                     ?LOG_INFO(
@@ -357,7 +357,7 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                             TargetPartition,
                             riak_core_format:human_size_fmt(
                                 "~.2f",
-                                TotalBytes + LastBatchSize
+                                TotalBytes + LastBatchByteSize
                             ),
                             TotalObjs + LastBatchLength - SkippedObjs,
                             TotalObjs + LastBatchLength,

--- a/src/riak_core_handoff_sender.erl
+++ b/src/riak_core_handoff_sender.erl
@@ -71,6 +71,7 @@
 
           total_objects        :: non_neg_integer(),
           total_bytes          :: non_neg_integer(),
+          filtered_objects = 0 :: non_neg_integer(),
 
           item_queue           :: [binary()],
           item_queue_length    :: non_neg_integer(),
@@ -209,13 +210,56 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                     "Initial sync message returned ~w error timeout "
                     "between src_partition=~p trg_partition=~p "
                     "type=~w module=~w ",
-                    [DirectionS,
-                        SrcPartition, TargetPartition,
-                        Type, Module]),
+                    [
+                        DirectionS,
+                        SrcPartition,
+                        TargetPartition,
+                        Type,
+                        Module
+                    ]
+                ),
                 exit({shutdown, timeout});
             {error, _, closed} ->
                 exit({shutdown, max_concurrency})
         end,
+
+        UpdFilter =
+            case {Type, lists:keyfind(origin, 1, Opts)} of
+                {repair, {origin, Origin}} ->
+                    NegativeFilters = 
+                        riak_core_vnode_manager:xfer_request_filter(
+                            Origin, 
+                            {Module, SrcPartition, TargetPartition}
+                        ),
+                    case NegativeFilters of
+                        ok ->
+                            Filter;
+                        NegativeFilters when is_list(NegativeFilters) ->
+                            ?LOG_INFO(
+                                "~w negative filters to be used in repair "
+                                "between ~w and ~w for ~w",
+                                [
+                                    length(NegativeFilters),
+                                    SrcPartition,
+                                    TargetPartition,
+                                    Module
+                                ]
+                            ),
+                            fun(K) ->
+                                case Filter(K) of
+                                    true ->
+                                        lists:all(
+                                            fun(F) -> not F(K) end,
+                                            NegativeFilters
+                                        );
+                                    NotTrue ->
+                                        NotTrue
+                                end
+                            end
+                    end;
+                _ ->
+                    Filter
+            end,
 
         ?LOG_INFO("Starting ~p transfer of ~p from ~p ~p to ~p ~p",
                 [Type, Module, SrcNode, SrcPartition,
@@ -226,7 +270,11 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
 
         Req = 
             riak_core_util:make_fold_req(
-                fun visit_item/3, HandoffAcc, false, FoldOpts),
+                fun visit_item/3,
+                HandoffAcc#ho_acc{filter=UpdFilter},
+                false,
+                FoldOpts
+            ),
 
         %% IFF the vnode is using an async worker to perform the fold
         %% then sync_command will return error on vnode crash,
@@ -253,9 +301,11 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
             module=Module,
             parent=ParentPid,
             tcp_mod=TcpMod,
-            total_objects=TotalObjects,
+            total_objects=TotalObjs,
             total_bytes=TotalBytes,
-            stats=FinalStats,
+            filtered_objects = SkippedObjs,
+            item_queue_length = LastBatchLength,
+            item_queue_byte_size = LastBatchSize,
             notsent_acc=NotSentAcc,
             rcv_timeout=RecvTimeout} = AccRecord,
 
@@ -277,29 +327,46 @@ start_fold(TargetNode, Module, {Type, Opts}, ParentPid, SslOpts) ->
                             "Final sync message returned ~w error timeout "
                             "between src_partition=~p trg_partition=~p "
                             "type=~w module=~w ",
-                            [DirectionE,
-                                SrcPartition, TargetPartition,
-                                Type, Module]
+                            [
+                                DirectionE,
+                                SrcPartition,
+                                TargetPartition,
+                                Type,
+                                Module
+                            ]
                         ),
                         exit({shutdown, timeout})
                 end,
 
                 FoldTimeDiff = end_fold_time(StartFoldTime),
-                ThroughputBytes = TotalBytes/FoldTimeDiff,
+                ThroughputBytes =
+                    (TotalBytes + LastBatchSize)/FoldTimeDiff,
 
                 ok = 
                     ?LOG_INFO(
                         "~p transfer of ~p from ~p ~p to ~p ~p"
                         " completed: sent ~s bytes in ~p of ~p objects"
                         " in ~.2f seconds (~s/second)",
-                        [Type, Module,
-                            SrcNode, SrcPartition,
-                            TargetNode, TargetPartition,
-                        riak_core_format:human_size_fmt(
-                            "~.2f", TotalBytes),
-                        FinalStats#ho_stats.objs, TotalObjects, FoldTimeDiff,
-                        riak_core_format:human_size_fmt(
-                            "~.2f", ThroughputBytes)]),
+                        [
+                            Type,
+                            Module,
+                            SrcNode,
+                            SrcPartition,
+                            TargetNode,
+                            TargetPartition,
+                            riak_core_format:human_size_fmt(
+                                "~.2f",
+                                TotalBytes + LastBatchSize
+                            ),
+                            TotalObjs + LastBatchLength - SkippedObjs,
+                            TotalObjs + LastBatchLength,
+                            FoldTimeDiff,
+                            riak_core_format:human_size_fmt(
+                                "~.2f",
+                                ThroughputBytes
+                            )
+                        ]
+                    ),
                 case Type of
                     repair ->
                         ok;
@@ -439,8 +506,10 @@ visit_item(K, V, Acc0) ->
             NewNotSentAcc = handle_not_sent_item(NotSentFun, NotSentAcc, K),
             Acc#ho_acc{
                 error=ok,
+                filtered_objects=Acc#ho_acc.filtered_objects + 1,
                 total_objects=TotalObjects+1,
-                notsent_acc=NewNotSentAcc}
+                notsent_acc=NewNotSentAcc
+            }
     end.
 
 handle_not_sent_item(NotSentFun, Acc, Key) when is_function(NotSentFun) ->
@@ -558,7 +627,7 @@ send_objects(ItemsReverseList, Acc) ->
     case TcpMod:send(Socket, M) of
         ok ->
             Acc0#ho_acc{ack=Ack+1, error=ok, stats=Stats3,
-                       total_objects=TotalObjects+NObjects,
+                       total_objects=TotalObjects+BatchCount,
                        total_bytes=TotalBytes+NumBytes,
                        keepalive_next=next_keepalive_time(),
                        item_queue=[],

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -19,134 +19,258 @@
 %% -------------------------------------------------------------------
 
 -module(riak_core_repair).
--export([gen_filter/5,
-         gen_range/3,
-         gen_range_map/3]).
+-export([gen_filter/5]).
 
 -include("riak_core_handoff.hrl").
--include_lib("kernel/include/logger.hrl").
 
--type hash_range()
-    :: 
-        {lt, non_neg_integer()} |
-        {gte, non_neg_integer()} |
-        {between, {gte, non_neg_integer()}, {lt, non_neg_integer()}} |
-        {either, {gte, non_neg_integer()}, {lt, non_neg_integer()}}.
+-type hash_range() :: list(non_neg_integer()).
 -type range_map() :: #{pos_integer() => hash_range()}.
+-type bucketkey() :: term().
+-type bucket() :: term().
 
 %% ===================================================================
 %% Public API
 %% ===================================================================
 
-%% @doc Generate a `Filter' fun to use during partition repair.
-%%
-%%      `Target' - Partition under repair.
-%%
-%%      `Ring' - The ring to use for repair.
-%%
-%%      `NValMap' - A map from bucket to `n_val', only custom buckets
-%%      have entries, everything else uses default.
-%%
-%%      `DefaultN' - The default `n_val'.
+%% @doc
+%% External function to generate filter.  Used to require an NvalMap of
+%% bucket -> n_val information as a proplist(), but this is now ignored as
+%% n_val information is collected dynamically during the fold.
+%% 
+%% The InfoFun must take a Bucket/Key and return a Bucket and a hash.
+%% 
+%% The work is done within gen_filter/6 - as this doesn't require riak_core to
+%% be running, and so is simpler to eunit test.
+-spec gen_filter(
+    index(),
+    riak_core_ring:riak_core_ring(),
+    any(),
+    pos_integer(),
+    fun((bucketkey()) -> {bucket(), binary()}))
+        -> fun((bucketkey()) -> boolean()).
 gen_filter(Target, Ring, _NValMap, DefaultN, InfoFun) ->
-    AllN = riak_core_bucket_type:all_n(),
-    RangeMap = riak_core_repair:gen_range_map(Target, Ring, AllN),
-    Default = riak_core_repair:gen_range(Target, Ring, DefaultN),
+    AllN_Types = riak_core_bucket_type:all_n(),
+    AllN_Legacy = riak_core_bucket:all_n(Ring),
+    AllN = lists:usort(AllN_Types ++ AllN_Legacy),
+    RingSize = element(1, riak_core_ring:chash(Ring)),
+    RingBits = trunc(math:log2(RingSize)),
+    NValFinder = fun nval_finder/1,
+    gen_filter(Target, RingBits, DefaultN, AllN, InfoFun, NValFinder).
+
+%% ===================================================================
+%% Internal functions
+%% ===================================================================
+
+%% @doc
+%% Get the nval for a bucket.  Function should handle both typed and untyped
+%% buckets
+-spec nval_finder(term()) -> false|{n_val, pos_integer()}.
+nval_finder(Bucket) ->
+    BucketProps = riak_core_bucket:get_bucket(Bucket),
+    lists:keyfind(n_val, 1, BucketProps).
+
+%% @doc
+%% Generate the filter.  The target will have the data from its NVal
+%% predecessors, so that is what we have to match.
+%% 
+%% The buckets will be learned as we traverse.  Fetching the bucket properties
+%% is fast due to cache mechanisms - but not as fast as accessing the process
+%% dictionary - and efficiency matters as this may be called >> 1K persec. So
+%% whenever the process learns of a new Type or Untyped bucket it should store
+%% that n_val information to use again, in a map on the process dictionary.
+%% 
+%% Note the actual checker cannot be cached against the bucket, as the process
+%% may need to apply multiple filters.  Only the hash and the nval will be
+%% consistent across multiple filters.
+%% 
+%% Likewise calls to the InfoFun are not free.  If there are multiple filters
+%% to be applied the handoff_sender process should set the last_hash Key in its
+%% process dictionary and the answer will not be cached.  Setting it to
+%% anything else will keep the hash cached until another Key is discovered
+-spec gen_filter(
+    index(),
+    pos_integer(),
+    pos_integer(),
+    list(pos_integer()),
+    fun((bucketkey()) -> {bucket(), binary()}),
+    fun((bucket()) -> false|{n_val, pos_integer()}))
+        -> fun((bucketkey()) -> boolean()).
+gen_filter(Target, RingBits, DefaultN, AllN, InfoFun, NValFinder) ->
+    RangeMap = gen_range_map(Target, RingBits, AllN),
+    Default = gen_range(Target, RingBits, DefaultN),
     fun(BKey) ->
         {Bucket, Hash} =
             case get(last_hash) of
                 no_cache ->
-                    {B, <<H:16/integer, _Rest/binary>>} = InfoFun(BKey),
-                    {BKey, B, H};
+                    {B, <<H:RingBits/integer, _/bitstring>>} = InfoFun(BKey),
+                    {B, H};
                 {BKey, B, H} ->
                     {B, H};
                 _ ->
-                    {B, <<H:16/integer, _Rest/binary>>} = InfoFun(BKey),
+                    {B, <<H:RingBits/integer, _/bitstring>>} = InfoFun(BKey),
                     put(last_hash, {BKey, B, H}),
                     {B, H}
             end,
-        NVal =
-            case get(Bucket) of
-                N when is_integer(N), N > 1 ->
-                    N;
-                undefined ->
-                    BucketProps = riak_core_bucket:get_bucket(Bucket),
-                    BucketN = lists:keyfind(n_val, 1, BucketProps),
-                    case BucketN of
-                        {n_val, N} when is_integer(N), N > 1 ->
-                            put(Bucket, N),
-                            N;
-                        _ ->
-                            default
-                    end
+        LookupB = case Bucket of {T, _TB} -> {type, T}; LB -> {bucket, LB} end,
+        BucketNValMap =
+            case get(nval_bucket_map) of
+                BNM when is_map(BNM) ->
+                    BNM;
+                _ ->
+                    maps:new()
             end,
-        case maps:get(NVal, RangeMap, Default) of
-            {lt, HighHash} ->
-                Hash < HighHash;
-            {gte, LowHash} ->
-                Hash > LowHash;
-            {between, {gte, LowHash}, {lt, HighHash}} ->
-                Hash >= LowHash andalso Hash < HighHash;
-            {either, {gte, LowHash}, {lt, HighHash}} ->
-                Hash >= LowHash orelse Hash < HighHash
-        end
+        MembershipChecker =
+            case maps:get(LookupB, BucketNValMap, not_cached) of
+                not_cached ->
+                    case NValFinder(Bucket) of
+                        {n_val, N} when is_integer(N) ->
+                            put(
+                                nval_bucket_map,
+                                maps:put(LookupB, {n_val, N}, BucketNValMap)
+                            ),
+                            maps:get(N, RangeMap, Default);
+                        _ ->
+                            put(
+                                nval_bucket_map,
+                                maps:put(LookupB, default, BucketNValMap)
+                            ),
+                            Default
+                    end;
+                {n_val, N} when is_integer(N), N > 0 ->
+                    maps:get(N, RangeMap, Default);
+                _ ->
+                    Default
+            end,
+        io:format("Checking for ~w in ~w", [Hash, MembershipChecker]),
+        lists:member(Hash, MembershipChecker)
     end.
 
 %% @doc Generate the hash `Range' for a given `Target' partition and
-%%      `NVal'.
+%% `NVal'.
+%% Hashes in riak_core are 160-bit integers, but if RingSize = 2 ^ RingBits
+%% only RingBits of that hash are interesting.
+%% Rather than comparing 160-bit integers or binaries for range equality just
+%% do a membership check of a small integer position against a list of nval
+%% positions
 -spec gen_range(
-    index(), riak_core_ring:riak_core_ring(), pos_integer()) ->
+    index(), pos_integer(), pos_integer()) ->
         hash_range().
-gen_range(Target, Ring, NVal) ->
-    CH = riak_core_ring:chash(Ring),
-    [LowPredecessor|RestPredecessors] =
-        lists:reverse(
-            lists:map(
-                fun({I, _N}) -> I bsr 144 end,
-                    % Use 16-bit integers for comparison not 160-bit
-                chash:predecessors(
-                    <<Target:160/integer>>,
-                    CH,
-                    NVal + 1 % predecessors includes itself
-                )
-            )
-        ),
-    case Target of
-        0 ->
-            {gte, LowPredecessor};
-        Target ->
-            T16 = Target bsr 144,
-            {A, B} =
-                lists:splitwith(
-                    fun(PB) -> PB > 0 end,
-                    [LowPredecessor|RestPredecessors]
-                ),
-            case {A, B} of
-                {_A, []} ->
-                    {
-                        between,
-                        {gte, LowPredecessor},
-                        {lt, T16}
-                    };
-                {[], _B} ->
-                    {lt, T16};
-                {A, _B} ->
-                    {
-                        either,
-                        {gte, LowPredecessor},
-                        {lt, T16}
-                    }
-            end
-    end.
+gen_range(Target, RingBits, NVal)
+        when
+            is_integer(Target), Target >= 0,
+            is_integer(RingBits), RingBits > 0,
+            is_integer(NVal), NVal > 0 ->
+    RingSize = 1 bsl RingBits,
+    TargetPos = Target bsr (160 - RingBits),
+    lists:map(
+        fun(I) -> (TargetPos + RingSize - I) rem RingSize end,
+        lists:seq(1, NVal)
+    ).
 
 %% @doc Generate the map from bucket `B' to hash `Range' that a key
 %%      must fall into to be included for repair on the `Target'
 %%      partition.
 -spec gen_range_map(
     index(),
-    riak_core_ring:riak_core_ring(),
+    pos_integer(),
     list(pos_integer())) -> range_map().
 gen_range_map(Target, Ring, NValList) ->
     NToRange = 
         lists:map(fun(N) -> {N, gen_range(Target, Ring, N)} end, NValList),
     maps:from_list(NToRange).
+
+
+%% ===================================================================
+%% Unit tests
+%% ===================================================================
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+basic_test() ->
+    %% Assume ring size of 64, so 6 bits
+    erase(),
+    Target54 = 54 bsl 154,
+    Source53 = 53 bsl 154,
+    RepairGenFun =
+        fun(T) ->
+            gen_filter(
+                T, 6, 3, [4, 5], fun test_hash64_fun/1, fun test_nval_finder/1)
+        end,
+    Filter54Fun = RepairGenFun(Target54),
+    Filter53Fun = RepairGenFun(Source53),
+    put(last_hash, no_cache),
+    Hash52To53 = <<52:6/integer, 1:1/integer, 0:153/integer>>,
+    ?assert(Filter54Fun({{<<"OtherType">>, <<"B1">>}, Hash52To53})),
+    ?assertMatch(no_cache, get(last_hash)),
+    ?assert(Filter53Fun({{<<"OtherType">>, <<"B1">>}, Hash52To53})),
+    NVM = get(nval_bucket_map),
+    ?assertMatch(default, maps:get({type, <<"OtherType">>}, NVM)),
+    ?assertNot(
+        Filter54Fun({{<<"OtherType">>, <<"B1">>},
+        <<Target54:160/integer>>})
+    ), % Self is not in, must be lt not lte
+    Hash49To50 = <<49:6/integer, 1:1/integer, 0:153/integer>>,
+    ?assertNot(Filter54Fun({<<"BucketDefault">>, Hash49To50})),
+    ?assertNot(Filter54Fun({<<"BucketDefault">>, Hash49To50})),
+    ?assertNot(Filter53Fun({<<"BucketDefault">>, Hash49To50})),
+    ?assertNot(Filter53Fun({<<"BucketDefault">>, Hash49To50})),
+    ?assert(Filter54Fun({<<"BucketN5">>, Hash49To50})),
+    ?assert(Filter54Fun({<<"BucketN5">>, Hash49To50})),
+    ?assertNot(Filter53Fun({<<"BucketDefault">>, Hash49To50})),
+        %check caching doesn't impact results
+    put(last_hash, undefined),
+    ?assertNot(Filter53Fun({<<"BucketDefault">>, Hash49To50})),
+    ?assert(Filter54Fun({<<"BucketN5">>, Hash49To50})),
+    ?assert(Filter54Fun({<<"BucketN5">>, Hash49To50})),
+    ?assertNot(Filter53Fun({<<"BucketDefault">>, Hash49To50})),
+    erase()
+    .
+
+wrapping_test() ->
+    erase(),
+    Target1 = 1 bsl 154,
+    Target0 = 0,
+    RepairGenFun =
+        fun(T) ->
+            gen_filter(
+                T, 6, 3, [4, 5], fun test_hash64_fun/1, fun test_nval_finder/1)
+        end,
+    Filter1Fun = RepairGenFun(Target1),
+    Filter0Fun = RepairGenFun(Target0),
+    put(last_hash, no_cache),
+    Hash52To53 = <<52:6/integer, 1:1/integer, 0:153/integer>>,
+    Hash00To01 = <<0:6/integer, 1:1/integer, 0:153/integer>>,
+    Hash63To00 = <<63:6/integer, 1:1/integer, 0:153/integer>>,
+    Hash62To63 = <<62:6/integer, 1:1/integer, 0:153/integer>>,
+    Hash61To62 = <<61:6/integer, 1:1/integer, 0:153/integer>>,
+    Hash60To61 = <<60:6/integer, 1:1/integer, 0:153/integer>>,
+    ?assertNot(Filter1Fun({{<<"TypeN4">>, <<"B1">>}, Hash52To53})),
+    ?assertNot(Filter0Fun({{<<"TypeN4">>, <<"B1">>}, Hash52To53})),
+    ?assert(Filter1Fun({{<<"TypeN4">>, <<"B2">>}, Hash00To01})),
+    ?assertNot(Filter0Fun({{<<"TypeN4">>, <<"B2">>}, Hash00To01})),
+    ?assert(Filter1Fun({{<<"TypeN4">>, <<"B3">>}, Hash63To00})),
+    ?assert(Filter0Fun({{<<"TypeN4">>, <<"B3">>}, Hash63To00})),
+    ?assert(Filter1Fun({{<<"TypeN4">>, <<"B3">>}, Hash62To63})),
+    ?assert(Filter0Fun({{<<"TypeN4">>, <<"B3">>}, Hash62To63})),
+    ?assert(Filter1Fun({{<<"TypeN4">>, <<"B4">>}, Hash61To62})),
+    ?assert(Filter0Fun({{<<"TypeN4">>, <<"B4">>}, Hash61To62})),
+    ?assertNot(Filter1Fun({{<<"TypeN4">>, <<"B4">>}, Hash60To61})),
+    ?assert(Filter0Fun({{<<"TypeN4">>, <<"B4">>}, Hash60To61})),
+    NVM = get(nval_bucket_map),
+    ?assertMatch([{type, <<"TypeN4">>}], maps:keys(NVM)),
+    erase().
+
+test_nval_finder({<<"TypeN4">>, _}) ->
+    {n_val, 4};
+test_nval_finder(<<"BucketN5">>) ->
+    {n_val, 5};
+test_nval_finder(<<"BucketDefault">>) ->
+    false;
+test_nval_finder(_) ->
+    false.
+
+test_hash64_fun({B, H}) ->
+    {B, H}.
+
+
+-endif.

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -222,8 +222,7 @@ basic_test() ->
     ?assert(Filter54Fun({<<"BucketN5">>, Hash49To50})),
     ?assert(Filter54Fun({<<"BucketN5">>, Hash49To50})),
     ?assertNot(Filter53Fun({<<"BucketDefault">>, Hash49To50})),
-    erase()
-    .
+    erase().
 
 wrapping_test() ->
     erase(),

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -141,7 +141,6 @@ gen_filter(Target, RingBits, DefaultN, AllN, InfoFun, NValFinder) ->
                 _ ->
                     Default
             end,
-        io:format("Checking for ~w in ~w", [Hash, MembershipChecker]),
         lists:member(Hash, MembershipChecker)
     end.
 

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -53,7 +53,18 @@ gen_filter(Target, Ring, _NValMap, DefaultN, InfoFun) ->
     RangeMap = riak_core_repair:gen_range_map(Target, Ring, AllN),
     Default = riak_core_repair:gen_range(Target, Ring, DefaultN),
     fun(BKey) ->
-        {Bucket, <<Hash:16/integer, _Rest/binary>>} = InfoFun(BKey),
+        {Bucket, Hash} =
+            case get(last_hash) of
+                no_cache ->
+                    {B, <<H:16/integer, _Rest/binary>>} = InfoFun(BKey),
+                    {BKey, B, H};
+                {BKey, B, H} ->
+                    {B, H};
+                _ ->
+                    {B, <<H:16/integer, _Rest/binary>>} = InfoFun(BKey),
+                    put(last_hash, {BKey, B, H}),
+                    {B, H}
+            end,
         NVal =
             case get(Bucket) of
                 N when is_integer(N), N > 1 ->

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -21,16 +21,17 @@
 -module(riak_core_repair).
 -export([gen_filter/5,
          gen_range/3,
-         gen_range_fun/2,
          gen_range_map/3]).
 
--include("riak_core_vnode.hrl").
+-include("riak_core_handoff.hrl").
 
-%% GTE = Greater Than or Equal
-%% LTE = Less Than or Equal
--type range_wrap() :: {wrap, GTE::binary(), LTE::binary()}.
--type range_nowrap() :: {nowrap, GTE::binary(), LTE::binary()}.
--type hash_range() :: range_wrap() | range_nowrap().
+-type hash_range()
+    :: 
+        {lt, non_neg_integer()} |
+        {gte, non_neg_integer()} |
+        {between, {gte, non_neg_integer()}, {lt, non_neg_integer()}} |
+        {either, {gte, non_neg_integer()}, {lt, non_neg_integer()}}.
+-type range_map() :: #{term() => hash_range()}.
 
 %% ===================================================================
 %% Public API
@@ -46,20 +47,20 @@
 %%      have entries, everything else uses default.
 %%
 %%      `DefaultN' - The default `n_val'.
-%%
-%%      `InfoFun' - A function which returns information about the key
-%%      used to determine if it should be repaired or not.
 gen_filter(Target, Ring, NValMap, DefaultN, InfoFun) ->
     RangeMap = riak_core_repair:gen_range_map(Target, Ring, NValMap),
     Default = riak_core_repair:gen_range(Target, Ring, DefaultN),
-    RangeFun = riak_core_repair:gen_range_fun(RangeMap, Default),
     fun(BKey) ->
-            {Bucket, Hash} = InfoFun(BKey),
-            case RangeFun(Bucket) of
-                {nowrap, GTE, LTE} ->
-                    Hash >= GTE andalso Hash =< LTE;
-                {wrap, GTE, LTE} ->
-                    Hash >= GTE orelse Hash =< LTE
+            {Bucket, <<Hash:160/integer>>} = InfoFun(BKey),
+            case maps:get(Bucket, RangeMap, Default) of
+                {lt, HighHash} ->
+                    Hash < HighHash;
+                {gte, LowHash} ->
+                    Hash > LowHash;
+                {between, {gte, LowHash}, {lt, HighHash}} ->
+                    Hash >= LowHash andalso Hash < HighHash;
+                {either, {gte, LowHash}, {lt, HighHash}} ->
+                    Hash >= LowHash orelse Hash < HighHash
             end
     end.
 
@@ -68,83 +69,64 @@ gen_filter(Target, Ring, NValMap, DefaultN, InfoFun) ->
 %%
 %% Note: The type of NVal should be pos_integer() but dialyzer says
 %%       success typing is integer() and I don't have time for games.
--spec gen_range(partition(), riak_core_ring:riak_core_ring(), integer()) ->
-                       hash_range().
+-spec gen_range(
+    index(), riak_core_ring:riak_core_ring(), integer()) ->
+        hash_range().
 gen_range(Target, Ring, NVal) ->
     CH = riak_core_ring:chash(Ring),
-    Predecessors = chash:predecessors(<<Target:160/integer>>, CH, NVal+1),
-    [{FirstIdx, Node}|Rest] = Predecessors,
-    Predecessors2 = [{FirstIdx-1, Node}|Rest],
-    Predecessors3 = [<<I:160/integer>> || {I,_} <- Predecessors2],
-    {A,B} = lists:splitwith(fun(E) -> E > <<0:160/integer>> end, Predecessors3),
-    case B of
-        [] ->
-            %% In this case there is no "wrap" around the end of the
-            %% ring so the range check it simply an inclusive
-            %% inbetween.
-            make_nowrap(A);
-
-        [<<0:160/integer>>] ->
-            %% In this case the 0th partition is first so no wrap
-            %% actually occurred.
-            make_nowrap(A ++ B);
-
+    [LowPredecessor|RestPredecessors] =
+        lists:reverse(
+            lists:map(
+                fun({I, _N}) -> I end,
+                chash:predecessors(
+                    <<Target:160/integer>>,
+                    CH,
+                    NVal + 1 % predecessors includes itself
+                )
+            )
+        ),
+    case Target of
+        0 ->
+            {gte, LowPredecessor};
         _ ->
-            %% In this case there is a "wrap" around the end of the
-            %% ring.  Either the key is greater than or equal the
-            %% largest or smaller than or equal to the smallest.
-            make_wrap(A, B)
-    end.
-
-
-%% @doc Generate the function that will return the hash range for a
-%%      given `Bucket'.
--spec gen_range_fun(list(), hash_range()) -> function().
-gen_range_fun(RangeMap, Default) ->
-    fun(Bucket) ->
-            case lists:keyfind(Bucket, 1, RangeMap) of
-                false -> Default;
-                {_, Val} -> Val
+            {A, B} =
+                lists:splitwith(
+                    fun(PB) -> PB > 0 end,
+                    [LowPredecessor|RestPredecessors]
+                ),
+            case {A, B} of
+                {_A, []} ->
+                    {
+                        between,
+                        {gte, LowPredecessor},
+                        {lt, Target}
+                    };
+                {[], _B} ->
+                    {lt, Target};
+                {A, _B} ->
+                    {
+                        either,
+                        {gte, LowPredecessor},
+                        {lt, Target}
+                    }
             end
     end.
 
 %% @doc Generate the map from bucket `B' to hash `Range' that a key
 %%      must fall into to be included for repair on the `Target'
 %%      partition.
--spec gen_range_map(partition(), riak_core_ring:riak_core_ring(), list()) ->
-                           [{Bucket::binary(), Range::hash_range()}].
-gen_range_map(Target, Ring, NValMap) ->
-    [{I, gen_range(Target, Ring, N)} || {I, N} <- NValMap, N > 1].
-
-
-%% ===================================================================
-%% Internal
-%% ===================================================================
-
-%% @private
-%%
-%% @doc Make the `nowrap' tuple representing the range a key hash must
-%% fall into.
--spec make_nowrap(list()) -> range_nowrap().
-make_nowrap(RingSlice) ->
-    Slice2 = lists:sort(RingSlice),
-    GTE = hd(Slice2),
-    LTE = lists:last(Slice2),
-    {nowrap, GTE, LTE}.
-
-%% @private
-%%
-%% @doc Make `wrap' tuple representing the two ranges, relative to 0,
-%% that a key hash must fall into.
-%%
-%% `RingSliceAfter' contains entries after the wrap around the 0th
-%% partition.  `RingSliceBefore' are entries before wrap and the
-%% including the wrap at partition 0.
--spec make_wrap(list(), list()) -> range_wrap().
-make_wrap(RingSliceAfter, RingSliceBefore) ->
-            LTE = hd(RingSliceAfter),
-            %% know first element of RingSliceBefore is 0
-            Before2 = tl(RingSliceBefore),
-            GTE = lists:last(Before2),
-            {wrap, GTE, LTE}.
-
+-spec gen_range_map(
+    index(),
+    riak_core_ring:riak_core_ring(),
+    list({term(), pos_integer()})) -> range_map().
+gen_range_map(Target, Ring, NValList) ->
+    Ns = lists:usort(lists:map(fun({_B, N}) -> N end, NValList)),
+    NToRange = lists:map(fun(N) -> {N, gen_range(Target, Ring, N)} end, Ns),
+    maps:from_list(
+        lists:map(
+            fun({B, N}) ->
+                {_N, Range} = lists:keyfind(N, 1, NToRange), {B, Range}
+            end,
+            NValList
+        )
+    ).

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -24,6 +24,7 @@
          gen_range_map/3]).
 
 -include("riak_core_handoff.hrl").
+-include_lib("kernel/include/logger.hrl").
 
 -type hash_range()
     :: 
@@ -31,7 +32,7 @@
         {gte, non_neg_integer()} |
         {between, {gte, non_neg_integer()}, {lt, non_neg_integer()}} |
         {either, {gte, non_neg_integer()}, {lt, non_neg_integer()}}.
--type range_map() :: #{term() => hash_range()}.
+-type range_map() :: #{pos_integer() => hash_range()}.
 
 %% ===================================================================
 %% Public API
@@ -47,21 +48,37 @@
 %%      have entries, everything else uses default.
 %%
 %%      `DefaultN' - The default `n_val'.
-gen_filter(Target, Ring, NValMap, DefaultN, InfoFun) ->
-    RangeMap = riak_core_repair:gen_range_map(Target, Ring, NValMap),
+gen_filter(Target, Ring, _NValMap, DefaultN, InfoFun) ->
+    AllN = riak_core_bucket_type:all_n(),
+    RangeMap = riak_core_repair:gen_range_map(Target, Ring, AllN),
     Default = riak_core_repair:gen_range(Target, Ring, DefaultN),
     fun(BKey) ->
-            {Bucket, <<Hash:160/integer>>} = InfoFun(BKey),
-            case maps:get(Bucket, RangeMap, Default) of
-                {lt, HighHash} ->
-                    Hash < HighHash;
-                {gte, LowHash} ->
-                    Hash > LowHash;
-                {between, {gte, LowHash}, {lt, HighHash}} ->
-                    Hash >= LowHash andalso Hash < HighHash;
-                {either, {gte, LowHash}, {lt, HighHash}} ->
-                    Hash >= LowHash orelse Hash < HighHash
-            end
+        {Bucket, <<Hash:16/integer, _Rest/binary>>} = InfoFun(BKey),
+        NVal =
+            case get(Bucket) of
+                N when is_integer(N), N > 1 ->
+                    N;
+                undefined ->
+                    BucketProps = riak_core_bucket:get_bucket(Bucket),
+                    BucketN = lists:keyfind(n_val, 1, BucketProps),
+                    case BucketN of
+                        {n_val, N} when is_integer(N), N > 1 ->
+                            put(Bucket, N),
+                            N;
+                        _ ->
+                            default
+                    end
+            end,
+        case maps:get(NVal, RangeMap, Default) of
+            {lt, HighHash} ->
+                Hash < HighHash;
+            {gte, LowHash} ->
+                Hash > LowHash;
+            {between, {gte, LowHash}, {lt, HighHash}} ->
+                Hash >= LowHash andalso Hash < HighHash;
+            {either, {gte, LowHash}, {lt, HighHash}} ->
+                Hash >= LowHash orelse Hash < HighHash
+        end
     end.
 
 %% @doc Generate the hash `Range' for a given `Target' partition and
@@ -74,7 +91,8 @@ gen_range(Target, Ring, NVal) ->
     [LowPredecessor|RestPredecessors] =
         lists:reverse(
             lists:map(
-                fun({I, _N}) -> I end,
+                fun({I, _N}) -> I bsr 144 end,
+                    % Use 16-bit integers for comparison not 160-bit
                 chash:predecessors(
                     <<Target:160/integer>>,
                     CH,
@@ -85,7 +103,8 @@ gen_range(Target, Ring, NVal) ->
     case Target of
         0 ->
             {gte, LowPredecessor};
-        _ ->
+        Target ->
+            T16 = Target bsr 144,
             {A, B} =
                 lists:splitwith(
                     fun(PB) -> PB > 0 end,
@@ -96,15 +115,15 @@ gen_range(Target, Ring, NVal) ->
                     {
                         between,
                         {gte, LowPredecessor},
-                        {lt, Target}
+                        {lt, T16}
                     };
                 {[], _B} ->
-                    {lt, Target};
+                    {lt, T16};
                 {A, _B} ->
                     {
                         either,
                         {gte, LowPredecessor},
-                        {lt, Target}
+                        {lt, T16}
                     }
             end
     end.
@@ -115,15 +134,8 @@ gen_range(Target, Ring, NVal) ->
 -spec gen_range_map(
     index(),
     riak_core_ring:riak_core_ring(),
-    list({term(), pos_integer()})) -> range_map().
+    list(pos_integer())) -> range_map().
 gen_range_map(Target, Ring, NValList) ->
-    Ns = lists:usort(lists:map(fun({_B, N}) -> N end, NValList)),
-    NToRange = lists:map(fun(N) -> {N, gen_range(Target, Ring, N)} end, Ns),
-    maps:from_list(
-        lists:map(
-            fun({B, N}) ->
-                {_N, Range} = lists:keyfind(N, 1, NToRange), {B, Range}
-            end,
-            NValList
-        )
-    ).
+    NToRange = 
+        lists:map(fun(N) -> {N, gen_range(Target, Ring, N)} end, NValList),
+    maps:from_list(NToRange).

--- a/src/riak_core_repair.erl
+++ b/src/riak_core_repair.erl
@@ -66,11 +66,8 @@ gen_filter(Target, Ring, NValMap, DefaultN, InfoFun) ->
 
 %% @doc Generate the hash `Range' for a given `Target' partition and
 %%      `NVal'.
-%%
-%% Note: The type of NVal should be pos_integer() but dialyzer says
-%%       success typing is integer() and I don't have time for games.
 -spec gen_range(
-    index(), riak_core_ring:riak_core_ring(), integer()) ->
+    index(), riak_core_ring:riak_core_ring(), pos_integer()) ->
         hash_range().
 gen_range(Target, Ring, NVal) ->
     CH = riak_core_ring:chash(Ring),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -35,9 +35,20 @@
 -export([start_link/0, stop/0]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2,
          terminate/2, code_change/3]).
--export([all_vnodes/0, all_vnodes/1, all_vnodes_status/0,
-         force_handoffs/0, repair/3, all_handoffs/0, repair_status/1, xfer_complete/2,
-         kill_repairs/1]).
+-export(
+    [
+        all_vnodes/0,
+        all_vnodes/1,
+        all_vnodes_status/0,
+        force_handoffs/0,
+        repair/3,
+        all_handoffs/0,
+        repair_status/1,
+        xfer_complete/2,
+        kill_repairs/1,
+        xfer_request_filter/2
+    ]
+).
 -export([all_index_pid/1, get_vnode_pid/2, start_vnode/2,
          unregister_vnode/2, unregister_vnode/3, vnode_event/4]).
 -export([repair_pairs/2]).
@@ -65,6 +76,7 @@
           filter_mod_fun        :: {module(), atom()},
           minus_one_xfer        :: xfer_status(),
           plus_one_xfer         :: xfer_status(),
+          filter_list = []      :: list(fun((term()) -> boolean())),
           pairs                 :: [{index(), node()}]
         }).
 -type repair() :: #repair{}.
@@ -82,7 +94,7 @@
 
 -include("riak_core.hrl").
 -include("riak_core_handoff.hrl").
--include("riak_core_vnode.hrl").
+
 -define(XFER_EQ(A, ModSrcTgt), A#xfer_status.mod_src_target == ModSrcTgt).
 -define(XFER_COMPLETE(X), X#xfer_status.status == complete).
 -define(DEFAULT_OWNERSHIP_TRIGGER, 8).
@@ -105,9 +117,9 @@ all_vnodes_status() ->
 
 %% @doc Repair the given `ModPartition' pair for `Service' using the
 %%      given `FilterModFun' to filter keys.
--spec repair(atom(), {module(), partition()}, {module(), atom()}) ->
-                    {ok, Pairs::[{partition(), node()}]} |
-                    {down, Down::[{partition(), node()}]} |
+-spec repair(atom(), {module(), index()}, {module(), atom()}) ->
+                    {ok, Pairs::[{index(), node()}]} |
+                    {down, Down::[{index(), node()}]} |
                     ownership_change_in_progress.
 repair(Service, {_Module, Partition}=ModPartition, FilterModFun) ->
     %% Fwd the request to the partition owner to guarantee that there
@@ -132,9 +144,20 @@ all_handoffs() ->
 %% TODO: make cast with retry on handoff sender side and handshake?
 %%
 %% TODO: second arg has specific form but maybe make proplist?
--spec xfer_complete(node(), tuple()) -> ok.
+-spec xfer_complete(node(), {module(), index(), index()}) -> ok.
 xfer_complete(Origin, Xfer) ->
     gen_server:call({?MODULE, Origin}, {xfer_complete, Xfer}, ?LONG_TIMEOUT).
+
+-spec xfer_request_filter(
+    node(), {module(), index(), index()}) ->
+        list(fun((term()) -> boolean()))|ok.
+%% @doc request negative filters, so any objects already being sent are not
+%% double-sent.  Note if this call is not supported (i.e. as running 3.2 or
+%% earlier) then an 'ok' will be returned as that is returned to any
+%% unrecognised call.  the 'ok' is reused for the no filter scenario, to prove
+%% this scenario (i.e. reduce cluster upgrade testing).
+xfer_request_filter(Origin, Xfer) ->
+    gen_server:call({?MODULE, Origin}, {xfer_filter, Xfer}, ?LONG_TIMEOUT).
 
 kill_repairs(Reason) ->
     gen_server:cast(?MODULE, {kill_repairs, Reason}).
@@ -162,6 +185,7 @@ get_tab() ->
 
 get_vnode_pid(Index, VNodeMod) ->
     gen_server:call(?MODULE, {Index, VNodeMod, get_vnode}, infinity).
+
 
 %% ===================================================================
 %% ETS-based API: try to determine response by reading protected ETS
@@ -348,6 +372,35 @@ handle_call({xfer_complete, ModSrcTgt}, _From, State) ->
             end
     end;
 
+handle_call({xfer_filter, ModSrcTarget}, _From, State) ->
+    Repairs = State#state.repairs,
+    {Mod, SrcPartition, Partition} = ModSrcTarget,
+    ModPartition = {Mod, Partition},
+    case get_repair(ModPartition, Repairs) of
+        Repair when is_record(Repair, repair) ->
+            {FilterMod, FilterFun} = Repair#repair.filter_mod_fun,
+            NegativeFilter = FilterMod:FilterFun(SrcPartition),
+            CurrentFilterList = Repair#repair.filter_list,
+            NextFilterList = CurrentFilterList ++ [NegativeFilter],
+            UpdRepair = Repair#repair{filter_list = NextFilterList},
+            case CurrentFilterList of
+                [] ->
+                    {
+                        reply,
+                        ok,
+                        State#state{repairs=replace_repair(UpdRepair, Repairs)}
+                    };
+                FilterFuns ->
+                    {
+                        reply,
+                        FilterFuns,
+                        State#state{repairs=replace_repair(UpdRepair, Repairs)}
+                    }
+            end;
+        _ ->
+            {reply, ok, State}
+    end;
+
 handle_call(_, _From, State) ->
     {reply, ok, State}.
 
@@ -392,11 +445,14 @@ create_repair(Pairs, ModPartition, FilterModFun, Mod, Partition, Repairs, State)
                              mod_src_target = {Mod, MOP, Partition}},
     POXStatus = #xfer_status{status = pending,
                              mod_src_target = {Mod, POP, Partition}},
-    Repair = #repair{mod_partition = ModPartition,
-                     filter_mod_fun = FilterModFun,
-                     pairs = Pairs,
-                     minus_one_xfer = MOXStatus,
-                     plus_one_xfer = POXStatus},
+    Repair =
+        #repair{
+            mod_partition = ModPartition,
+            filter_mod_fun = FilterModFun,
+            pairs = Pairs,
+            minus_one_xfer = MOXStatus,
+            plus_one_xfer = POXStatus
+        },
     Repairs2 = Repairs ++ [Repair],
     State2 = State#state{repairs = Repairs2},
     ?LOG_DEBUG("add repair ~p", [ModPartition]),

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -51,7 +51,6 @@
 ).
 -export([all_index_pid/1, get_vnode_pid/2, start_vnode/2,
          unregister_vnode/2, unregister_vnode/3, vnode_event/4]).
--export([repair_pairs/2]).
 %% Field debugging
 -export([get_tab/0]).
 
@@ -64,21 +63,23 @@
 -record(idxrec, {key, idx, mod, pid, monref}).
 -record(monrec, {monref, key}).
 
--record(xfer_status, {
-          status                :: pending | complete,
-          mod_src_target        :: {module(), index(), index()}
-         }).
+-record(xfer_status,
+    {
+        status                :: pending | complete,
+        mod_src_target        :: {module(), index(), index()}
+    }
+).
 -type xfer_status() :: #xfer_status{}.
 
 -record(repair,
-        {
-          mod_partition         :: mod_partition(),
-          filter_mod_fun        :: {module(), atom()},
-          minus_one_xfer        :: xfer_status(),
-          plus_one_xfer         :: xfer_status(),
-          filter_list = []      :: list(fun((term()) -> boolean())),
-          pairs                 :: [{index(), node()}]
-        }).
+    {
+        mod_partition         :: mod_partition(),
+        filter_mod_fun        :: {module(), atom()},
+        status_list = []      :: list({{index(), node()}, xfer_status()}),
+        filter_list = []      :: list(fun((term()) -> boolean())),
+        repairers             :: [{index(), node()}]
+    }
+).
 -type repair() :: #repair{}.
 -type repairs() :: [repair()].
 
@@ -95,8 +96,6 @@
 -include("riak_core.hrl").
 -include("riak_core_handoff.hrl").
 
--define(XFER_EQ(A, ModSrcTgt), A#xfer_status.mod_src_target == ModSrcTgt).
--define(XFER_COMPLETE(X), X#xfer_status.status == complete).
 -define(DEFAULT_OWNERSHIP_TRIGGER, 8).
 -define(ETS, ets_vnode_mgr).
 -define(DEFAULT_VNODE_ROLLING_START, 16).
@@ -321,8 +320,8 @@ handle_call({repair, Service, {Mod,Partition}=ModPartition, FilterModFun},
         none ->
             maybe_create_repair(Partition, Service, ModPartition, FilterModFun, Mod, Repairs, State);
         Repair ->
-            Pairs = Repair#repair.pairs,
-            {reply, {ok, Pairs}, State}
+            Repairers = Repair#repair.repairers,
+            {reply, {ok, Repairers}, State}
     end;
 
 handle_call(all_handoffs, _From, State=#state{repairs=Repairs, handoff=HO}) ->
@@ -344,31 +343,55 @@ handle_call({repair_status, ModPartition}, _From, State) ->
 %%       2. The target partition is always a local, primary partition.
 handle_call({xfer_complete, ModSrcTgt}, _From, State) ->
     Repairs = State#state.repairs,
-    {Mod, _, Partition} = ModSrcTgt,
-    ModPartition = {Mod, Partition},
+    {Mod, SrcPartition, Target} = ModSrcTgt,
+    ModPartition = {Mod, Target},
     case get_repair(ModPartition, Repairs) of
         none ->
-            ?LOG_ERROR("Received xfer_complete for non-existing repair: ~p",
-                        [ModPartition]),
+            ?LOG_ERROR(
+                "Received xfer_complete for non-existing repair: ~p",
+                [ModPartition]
+            ),
             {reply, ok, State};
-        #repair{minus_one_xfer=MOX, plus_one_xfer=POX}=R ->
-            R2 = if ?XFER_EQ(MOX, ModSrcTgt) ->
-                         MOX2 = MOX#xfer_status{status=complete},
-                         R#repair{minus_one_xfer=MOX2};
-                    ?XFER_EQ(POX, ModSrcTgt) ->
-                         POX2 = POX#xfer_status{status=complete},
-                         R#repair{plus_one_xfer=POX2};
-                    true ->
-                         ?LOG_ERROR("Received xfer_complete for "
-                                     "non-existing xfer: ~p", [ModSrcTgt])
-                 end,
-
-            case {?XFER_COMPLETE(R2#repair.minus_one_xfer),
-                  ?XFER_COMPLETE(R2#repair.plus_one_xfer)} of
-                {true, true} ->
-                    {reply, ok, State#state{repairs=remove_repair(R2, Repairs)}};
+        Repair ->
+            StatusList =
+                lists:map(
+                    fun({Src, XferStatus}) ->
+                        case Src of
+                            {SrcPartition, SrcNode} ->
+                                UpdStatus = XferStatus#xfer_status{status = complete},
+                                {{SrcPartition, SrcNode}, UpdStatus};
+                            OtherXfer ->
+                                {OtherXfer, XferStatus}
+                        end
+                    end,
+                    Repair#repair.status_list
+                ),
+            AllComplete =
+                lists:all(
+                    fun({_, XferStatus}) ->
+                        XferStatus#xfer_status.status == complete
+                    end,
+                    StatusList
+                ),
+            case AllComplete of
+                true ->
+                    {
+                        reply,
+                        ok,
+                        State#state{repairs=remove_repair(Repair, Repairs)}
+                    };
                 _ ->
-                    {reply, ok, State#state{repairs=replace_repair(R2, Repairs)}}
+                    {
+                        reply,
+                        ok,
+                        State#state{
+                            repairs =
+                                replace_repair(
+                                    Repair#repair{status_list = StatusList},
+                                    Repairs
+                                )
+                            }
+                    }
             end
     end;
 
@@ -405,26 +428,40 @@ handle_call(_, _From, State) ->
     {reply, ok, State}.
 
 transform_repair_records(Repairs) ->
-    %% World's ugliest pattern match, simplest logic: matching
-    %% module/node values in the `pairs' field against
-    %% `minus_one_xfer' and `plus_one_xfer'
-    lists:flatten(lists:map(fun(#repair{pairs=[{M1SrcIdx, Mnode}, _FixPartition, {P1SrcIdx, Pnode}],
-                                        minus_one_xfer=#xfer_status{mod_src_target={M1Mod, M1SrcIdx, _M1DstIdx}},
-                                        plus_one_xfer=#xfer_status{mod_src_target={P1Mod, P1SrcIdx, _P1DstIdx}}}) ->
-                                    [{{M1Mod, M1SrcIdx}, {repair, inbound, Mnode}},
-                                     {{P1Mod, P1SrcIdx}, {repair, inbound, Pnode}}]
-                            end,
-                            Repairs)).
+    lists:flatten(
+        lists:map(
+            fun(#repair{repairers = Repairers, status_list = StatusList}) ->
+                lists:map(
+                    fun(Repairer) ->
+                        {{SrcP, SrcNode}, Status} =
+                            lists:keyfind(Repairer, 1, StatusList),
+                        {Mod, SrcP, _T} = Status#xfer_status.mod_src_target,
+                        {{Mod, SrcP}, {repair, inbound, SrcNode}}
+                    end,
+                    Repairers
+                )
+            end,
+            Repairs
+        )
+    ).
 
 maybe_create_repair(Partition, Service, ModPartition, FilterModFun, Mod, Repairs, State) ->
     {ok, Ring} = riak_core_ring_manager:get_my_ring(),
     case riak_core_ring:pending_changes(Ring) of
         [] ->
             UpNodes = riak_core_node_watcher:nodes(Service),
-            Pairs = repair_pairs(Ring, Partition),
-            case check_up(Pairs, UpNodes) of
+            Repairers = discover_repairers(Ring, Partition),
+            case check_up(Repairers, UpNodes) of
                 true ->
-                    create_repair(Pairs, ModPartition, FilterModFun, Mod, Partition, Repairs, State);
+                    create_repair(
+                        Repairers,
+                        ModPartition,
+                        FilterModFun,
+                        Mod,
+                        Partition,
+                        Repairs,
+                        State
+                    );
                 {false, Down} ->
                     {reply, {down, Down}, State}
             end;
@@ -432,31 +469,40 @@ maybe_create_repair(Partition, Service, ModPartition, FilterModFun, Mod, Repairs
             {reply, ownership_change_in_progress, State}
     end.
 
-create_repair(Pairs, ModPartition, FilterModFun, Mod, Partition, Repairs, State) ->
-    {MOP, _} = MinusOne = get_minus_one(Pairs),
-    {POP, _} = PlusOne = get_plus_one(Pairs),
-    riak_core_handoff_manager:xfer(MinusOne,
-                                   ModPartition,
-                                   FilterModFun),
-    riak_core_handoff_manager:xfer(PlusOne,
-                                   ModPartition,
-                                   FilterModFun),
-    MOXStatus = #xfer_status{status = pending,
-                             mod_src_target = {Mod, MOP, Partition}},
-    POXStatus = #xfer_status{status = pending,
-                             mod_src_target = {Mod, POP, Partition}},
+create_repair(
+        Repairers,
+        ModPartition,
+        FilterModFun,
+        Mod,
+        Partition,
+        Repairs,
+        State) ->
+    RepairStatusList =
+        lists:map(
+            fun(Repairer) ->
+                {SrcP, _SrcNode} = Repairer,
+                riak_core_handoff_manager:xfer(Repairer, ModPartition, FilterModFun),
+                {
+                    Repairer,
+                    #xfer_status{
+                        status = pending,
+                        mod_src_target = {Mod, SrcP, Partition}
+                    }
+                }
+            end,
+            Repairers
+        ),
     Repair =
         #repair{
             mod_partition = ModPartition,
             filter_mod_fun = FilterModFun,
-            pairs = Pairs,
-            minus_one_xfer = MOXStatus,
-            plus_one_xfer = POXStatus
+            repairers = Repairers,
+            status_list = RepairStatusList
         },
     Repairs2 = Repairs ++ [Repair],
     State2 = State#state{repairs = Repairs2},
     ?LOG_DEBUG("add repair ~p", [ModPartition]),
-    {reply, {ok, Pairs}, State2}.
+    {reply, {ok, Repairers}, State2}.
 
 %% @private
 handle_cast({Partition, Mod, start_vnode}, State) ->
@@ -979,22 +1025,20 @@ maybe_start_vnodes(State=#state{vnode_start_tokens=Tokens,
 
 -spec check_repairs(repairs()) -> Repairs2::repairs().
 check_repairs(Repairs) ->
-    Check =
-        fun(R=#repair{minus_one_xfer=MOX, plus_one_xfer=POX}, Repairs2) ->
-                Pairs = R#repair.pairs,
-                MO = get_minus_one(Pairs),
-                PO = get_plus_one(Pairs),
-                MOX2 = maybe_retry(R, MO, MOX),
-                POX2 = maybe_retry(R, PO, POX),
-
-                if ?XFER_COMPLETE(MOX2) andalso ?XFER_COMPLETE(POX2) ->
-                        Repairs2;
-                   true ->
-                        R2 = R#repair{minus_one_xfer=MOX2, plus_one_xfer=POX2},
-                        [R2|Repairs2]
-                end
+    CheckFun =
+        fun(Repair) ->
+            StatusList = Repair#repair.status_list,
+            lists:foreach(
+                fun(Repairer) ->
+                    {Repairer, XferStatus} =
+                        lists:keyfind(Repairer, 1, StatusList),
+                    maybe_retry(Repair, Repairer, XferStatus)
+                end,
+                Repair#repair.repairers
+            )
         end,
-    lists:reverse(lists:foldl(Check, [], Repairs)).
+    lists:foreach(CheckFun, Repairs),
+    Repairs.
 
 %% TODO: get all this repair, xfer status and Src business figured out.
 -spec maybe_retry(repair(), tuple(), xfer_status()) -> Xfer2::xfer_status().
@@ -1026,16 +1070,22 @@ check_up(Pairs, UpNodes) ->
 
 %% @private
 %%
-%% @doc Get the three `{Partition, Owner}' pairs involved in a repair
-%%      operation for the given `Ring' and `Partition'.
--spec repair_pairs(riak_core_ring:riak_core_ring(), non_neg_integer()) ->
-                          [{Partition::non_neg_integer(), Owner::node()}].
-repair_pairs(Ring, Partition) ->
-    Owner = riak_core_ring:index_owner(Ring, Partition),
+%% @doc Get a list of partition owners that may contribute to the repair job
+-spec discover_repairers(
+    riak_core_ring:riak_core_ring(), non_neg_integer()) ->
+        [{Partition::non_neg_integer(), Owner::node()}].
+discover_repairers(Ring, Partition) ->
     CH = riak_core_ring:chash(Ring),
-    [_, Before] = chash:predecessors(<<Partition:160/integer>>, CH, 2),
-    [After] = chash:successors(<<Partition:160/integer>>, CH, 1),
-    [Before, {Partition, Owner}, After].
+    case application:get_env(riak_core, repair_span, pair) of
+        double_pair ->
+            [_, B1, B2] = chash:predecessors(<<Partition:160/integer>>, CH, 3),
+            [A1, A2] = chash:successors(<<Partition:160/integer>>, CH, 2),
+            [A1, A2, B1, B2];
+        _ ->
+            [_, B1] = chash:predecessors(<<Partition:160/integer>>, CH, 2),
+            [A1] = chash:successors(<<Partition:160/integer>>, CH, 1),
+            [A1, B1]
+    end.
 
 %% @private
 %%
@@ -1065,22 +1115,6 @@ replace_repair(Repair, Repairs) ->
 
 %% @private
 %%
-%% @doc Get the `{Partition, Owner}' pair that comes before the
-%%      partition under repair.
--spec get_minus_one([{index(), node()}]) -> {index(), node()}.
-get_minus_one([MinusOne, _, _]) ->
-    MinusOne.
-
-%% @private
-%%
-%% @doc Get the `{Partition, Owner}' pair that comes after the
-%%      partition under repair.
--spec get_plus_one([{index(), node()}]) -> {index(), node()}.
-get_plus_one([_, _, PlusOne]) ->
-    PlusOne.
-
-%% @private
-%%
 %% @doc Kill all outbound and inbound xfers related to `Repairs'
 %%      targeting this node with `Reason'.
 -spec kill_repairs([repair()], term()) -> ok.
@@ -1089,25 +1123,21 @@ kill_repairs(Repairs, Reason) ->
     ok.
 
 kill_repair(Repair, Reason) ->
-    {Mod, Partition} = Repair#repair.mod_partition,
-    Pairs = Repair#repair.pairs,
-    {_,MOOwner} = get_minus_one(Pairs),
-    {_,POOwner} = get_minus_one(Pairs),
-    MOX = Repair#repair.minus_one_xfer,
-    POX = Repair#repair.plus_one_xfer,
-    MOModSrcTarget = MOX#xfer_status.mod_src_target,
-    POModSrcTarget = POX#xfer_status.mod_src_target,
-    %% Kill the remote senders
-    riak_core_handoff_manager:kill_xfer(MOOwner,
-                                        MOModSrcTarget,
-                                        Reason),
-    riak_core_handoff_manager:kill_xfer(POOwner,
-                                        POModSrcTarget,
-                                        Reason),
+    {Mod, TargetP} = Repair#repair.mod_partition,
+    Repairers = Repair#repair.repairers,
+    lists:foreach(
+        fun({SrcP, SrcNode}) ->
+            riak_core_handoff_manager:kill_xfer(
+                SrcNode,
+                {Mod, SrcP, TargetP},
+                Reason
+            )
+        end,
+        Repairers
+    ),
     %% Kill the local receivers
-    riak_core_handoff_manager:kill_xfer(node(),
-                                        {Mod, undefined, Partition},
-                                        Reason).
+    riak_core_handoff_manager:kill_xfer(
+        node(), {Mod, undefined, TargetP}, Reason).
 
 register_vnode_stats(Mod, Index, Pid) ->
     riak_core_stat:register_vnode_stats(Mod, Index, Pid).

--- a/src/riak_core_vnode_manager.erl
+++ b/src/riak_core_vnode_manager.erl
@@ -40,6 +40,7 @@
          kill_repairs/1]).
 -export([all_index_pid/1, get_vnode_pid/2, start_vnode/2,
          unregister_vnode/2, unregister_vnode/3, vnode_event/4]).
+-export([repair_pairs/2]).
 %% Field debugging
 -export([get_tab/0]).
 

--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -244,15 +244,21 @@ handle_info(log_timer, StateName, State) ->
             _ = 
                 ?LOG_INFO(
                     "worker_pool=~w has qlen=~w with last_checkout=~w ms ago",
-                    [State#state.pool_name,
+                    [
+                        State#state.pool_name,
                         QL,
-                        LastCheckout  div 1000]),
+                        LastCheckout  div 1000
+                    ],
+                    #{log_type => metric}
+                ),
             ok;
         {true, []} ->
             _ =
                 ?LOG_INFO(
                     "worker_pool=~w has qlen=0 and no items checked out",
-                    [State#state.pool_name]);
+                    [State#state.pool_name],
+                #{log_type => metric}
+                );
         _ ->
             ok
     end,

--- a/src/riak_core_worker_pool.erl
+++ b/src/riak_core_worker_pool.erl
@@ -247,7 +247,7 @@ handle_info(log_timer, StateName, State) ->
                     [
                         State#state.pool_name,
                         QL,
-                        LastCheckout  div 1000
+                        LastCheckout div 1000
                     ],
                     #{log_type => metric}
                 ),


### PR DESCRIPTION
There are four main parts to this refactoring:

- Allow for handoff-type specific fold options. to be passed back to the `riak_core_handoff_sender` from `Mod:handoff_started/2` (this is then used by riak_kv to turn fold_objects queries into fold_heads with deferred fetching).
- Expand the width of vnodes to be involved in repairs from a pair (i.e. one either side), to a double-pair (two either side).
- Add negative filters to handoff, so that riak_core_repair filters can be used to check not just if a Key is in the target, but if the Key is not in the range of another source that has already commenced handoff.
- Update riak_core_repair to use small integers of log2(RingSize) bits rather than 160-bit integers.

The net effect is that multiple repairs for each vnode will be triggered, but the the losers of the race to start will have less work to do (and potentially no work).  By using fold_heads with deferred fetch, there is minimal work when losing the race.  This allows for busier nodes to avoid repair work, and for less busy nodes to pick up the slack.