### PR TITLE
Nhse o34 orkv.i28 popfalse

### DIFF
--- a/priv/riak_core.schema
+++ b/priv/riak_core.schema
@@ -37,6 +37,23 @@
   Size >= 8
  end}.
 
+%% @doc Whether the erlang kernel `global` application should prevent
+%% overlapping partitions.
+%% Without disabling, this will default to `on` in OTP 25.  As Riak is
+%% partition tolerant by design this should be set to `off`.
+%% There may be circumstances where partition tolerance is considered to be
+%% undesirable, e.g. when trying to strengthen the consistency when using the
+%% Token-based conditional PUTs, but reverting to `on` is still not tested even
+%% in these cases.
+%% Setting this prevention to `on` may cause errors in some standard cluster
+%% change operations due to delays in different nodes recognising nodes joining
+%% a cluster
+{mapping, "prevent_overlapping_partitions", "kernel.prevent_overlapping_partitions", [
+    {datatype, flag},
+    {default, off},
+    hidden
+]}.
+
 %% @doc Number of concurrent node-to-node transfers allowed.
 %% It is generally safe to raise this number to increase concurrency.  A
 %% common value to use would be 8.  However, it is necessary to monitor for

--- a/rebar.config
+++ b/rebar.config
@@ -30,7 +30,7 @@
 {dialyzer, [{plt_apps, all_deps}]}.
 
 {profiles, [
-    {test, [{deps, [meck]}, {erl_opts, [nowarn_export_all]}]},
-    {eqc, [{deps, [meck]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
-    {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [nowarn_export_all]}]},
+    {eqc,  [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}, {erl_opts, [{d, 'EQC'}, nowarn_export_all]}]},
+    {gha,  [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.


### PR DESCRIPTION
Set `prevent_overlapping_partitions` to `false` to override change of default in OTP 25.