### PR TITLE
Add support for {F, async} as a data_size option

### DIFF
--- a/include/riak_core_handoff.hrl
+++ b/include/riak_core_handoff.hrl
@@ -23,6 +23,12 @@
 -type mod_src_tgt() :: {module(), index(), index()} | {undefined, undefined, undefined}.
 -type mod_partition() :: {module(), index()}.
 
+-type db_dynamic_size_fun()
+  :: fun(() -> db_size()).
+-type db_size_result() :: {non_neg_integer(), bytes | objects}.
+-type db_size()
+  :: {db_dynamic_size_fun(), dynamic} | db_size_result().
+
 -record(handoff_status,
         { mod_src_tgt           :: mod_src_tgt(),
           src_node              :: node(),
@@ -38,7 +44,7 @@
           type = undefined      :: ho_type() | undefined,
           req_origin            :: node(),
           filter_mod_fun        :: {module(), atom()} | undefined,
-          size = {0, objects}   :: {function(), dynamic} | {non_neg_integer(), bytes | objects}
+          size = {0, objects}   :: db_size() | undefined
         }).
 -type handoff_status() :: #handoff_status{}.
 

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -414,12 +414,13 @@ get_size(S) ->
     non_neg_integer(),
     non_neg_integer(),
     db_size_result() | undefined) -> float() | undefined.
-calc_pct_done(_, _, undefined) ->
-    undefined;
-calc_pct_done(Objs, _, {Size, objects}) ->
+calc_pct_done(Objs, _, {Size, objects}) when is_integer(Size), Size > 0 ->
     Objs / Size;
-calc_pct_done(_, Bytes, {Size, bytes}) ->
-    Bytes / Size.
+calc_pct_done(_, Bytes, {Size, bytes})  when is_integer(Size), Size > 0 ->
+    Bytes / Size;
+calc_pct_done(_, _, _) ->
+    % Will normally expect in this case that db_size_result is undefined
+    undefined.
 
 filter(none) ->
     fun(_) -> true end;

--- a/src/riak_core_handoff_manager.erl
+++ b/src/riak_core_handoff_manager.erl
@@ -404,11 +404,16 @@ calc_stats(#handoff_status{stats=Stats,timestamp=StartTS,size=Size}) ->
              {pct_done_decimal, Done}]
     end.
 
+-spec get_size(db_size()|undefined) -> db_size_result()|undefined.
 get_size({F, dynamic}) ->
     F();
 get_size(S) ->
     S.
 
+-spec calc_pct_done(
+    non_neg_integer(),
+    non_neg_integer(),
+    db_size_result() | undefined) -> float() | undefined.
 calc_pct_done(_, _, undefined) ->
     undefined;
 calc_pct_done(Objs, _, {Size, objects}) ->
@@ -588,12 +593,17 @@ update_stats(StatsUpdate, Stats) ->
     Stats3 = dict:update_counter(bytes, Bytes, Stats2),
     dict:store(last_update, LU, Stats3).
 
-validate_size(Size={N, U}) when is_number(N) andalso
-                           N > 0 andalso
-                           (U =:= bytes orelse U =:= objects) ->
+
+-spec validate_size(
+    db_size()|{db_dynamic_size_fun(), async}) -> db_size()|undefined.
+validate_size(Size={N, U})
+    when 
+        is_number(N), N > 0, (U =:= bytes orelse U =:= objects) ->
     Size;
-validate_size(Size={F, dynamic}) when is_function(F) ->
+validate_size(Size={F, dynamic}) when is_function(F, 0) ->
     Size;
+validate_size({F, async}) when is_function(F, 0) ->
+    validate_size(F());
 validate_size(_) ->
     undefined.
 


### PR DESCRIPTION
This is intended for backends where it is convenient to return a function, (because the size is too expensive to calculate synchronously), but expensive to recalculate continuously (as would happen with {F, dynamic}, where the size is recalculated for every user CLI request for handoff/transfer status.

It would also be possible for the F() in {F, async} to return {F0, dynamic} should this be required.