### PR TITLE
ssl_cipher_format:suite_bin_to_map/1 no longer needed for suite_map_to_openssl_str/1

### DIFF
--- a/src/riak_core_ssl_util.erl
+++ b/src/riak_core_ssl_util.erl
@@ -48,7 +48,7 @@ ssl_handshake(Socket, SslOpts) ->
 openssl_suite(Cipher) ->
     ssl_cipher_format:suite_openssl_str_to_map(Cipher).
 openssl_suite_name(Cipher) ->
-    ssl_cipher_format:suite_map_to_openssl_str(ssl_cipher_format:suite_bin_to_map(Cipher)).
+    ssl_cipher_format:suite_map_to_openssl_str(Cipher).
 
 
 maybe_use_ssl(App) ->


### PR DESCRIPTION
A fix for this breakage:

```
# riak admin security ciphers
Configured ciphers

:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:DHE-DSS-AES256-GCM-SHA384:DHE-RSA-AES256-GCM-SHA384:ADH-AES256-GCM-SHA384:ADH-AES128-GCM-SHA256:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:SRP-DSS-AES-128-CBC-SHA:SRP-RSA-AES-128-CBC-SHA:DHE-DSS-AES128-SHA:AECDH-AES128-SHA:SRP-AES-128-CBC-SHA:ADH-AES128-SHA256:ADH-AES128-SHA:AES128-SHA256:AES128-SHA:SRP-DSS-AES-256-CBC-SHA:SRP-RSA-AES-256-CBC-SHA:DHE-DSS-AES256-SHA256:AECDH-AES256-SHA:SRP-AES-256-CBC-SHA:ADH-AES256-SHA256:ADH-AES256-SHA:AES256-SHA256:AES256-SHA:RC4-SHA:DHE-RSA-CAMELLIA256-SHA:DHE-DSS-CAMELLIA256-SHA:ADH-CAMELLIA256-SHA:CAMELLIA256-SHA:DHE-RSA-CAMELLIA128-SHA:DHE-DSS-CAMELLIA128-SHA:ADH-CAMELLIA128-SHA:CAMELLIA128-SHA

RPC to 'riak@172.17.0.2' failed: {'EXIT',
                                  {function_clause,
                                   [{ssl_cipher_format,suite_bin_to_map,
                                     [#{cipher => aes_128_gcm,
                                        key_exchange => dhe_rsa,mac => aead,
                                        prf => sha256}],
                                     [{file,"ssl_cipher_format.erl"},
                                      {line,206}]},
                                    {riak_core_ssl_util,openssl_suite_name,1,
                                     [{file,
                                       "/home/dev/src/riak/_build/default/lib/riak_core/src/riak_core_ssl_util.erl"},
                                      {line,51}]},
                                    {riak_core_ssl_util,
                                     '-print_ciphers/1-lc$^0/1-0-',1,
                                     [{file,
                                       "/home/dev/src/riak/_build/default/lib/riak_core/src/riak_core_ssl_util.erl"},
                                      {line,340}]},
                                    {riak_core_ssl_util,print_ciphers,1,
                                     [{file,
                                       "/home/dev/src/riak/_build/default/lib/riak_core/src/riak_core_ssl_util.erl"},
                                      {line,340}]},
                                    {riak_core_security,print_ciphers,0,
                                     [{file,
                                       "/home/dev/src/riak/_build/default/lib/riak_core/src/riak_core_security.erl"},
                                      {line,791}]},
                                    {riak_core_console,ciphers,1,[]}]}}
```

Likely a fixup for https://github.com/OpenRiak/riak_core/commit/abbcca3.