### PR TITLE
Sort sources correctly so that 'all' comes last

### DIFF
--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1129,10 +1129,10 @@ group_sources(Sources) ->
                     case {UserA, UserB} of
                         {[all], [all]} ->
                             true;
-                        {[all], _} ->
-                            %% anything is greater than 'all'
-                            true;
                         {_, [all]} ->
+                            %% anything should come before 'all'
+                            true;
+                        {[all], _} ->
                             false;
                         {_, _} ->
                             true

--- a/src/riak_core_security.erl
+++ b/src/riak_core_security.erl
@@ -1085,15 +1085,15 @@ match_source([{UserName, {IP,Mask}, Source, Options}|Tail], User, PeerIP) ->
 
 sort_sources(Sources) ->
     %% sort sources first by userlist, so that 'all' matches come last
-    %% and then by CIDR, so that most sprcific masks come first
+    %% and then by CIDR, so that most specific masks come first
     Sources1 = lists:sort(fun({UserA, _, _, _}, {UserB, _, _, _}) ->
                     case {UserA, UserB} of
                         {all, all} ->
                             true;
-                        {all, _} ->
-                            %% anything is greater than 'all'
-                            true;
                         {_, all} ->
+                            %% anything should come before 'all'
+                            true;
+                        {all, _} ->
                             false;
                         {_, _} ->
                             true


### PR DESCRIPTION
sort_sources/1 is supposed to put 'all' matches at the end of the list.

Therefore, the ordering function should return `false` for `{all, _}`, given the rule that Fun(A, B) is to return `true` only if A compares less than or equal to B in the ordering.