### PR TITLE
supps: add riak_admin_api_sup to list of top-level sups

### DIFF
--- a/src/riak_core_supps.erl
+++ b/src/riak_core_supps.erl
@@ -55,6 +55,7 @@ sups() ->
      riak_kv_sup,
      riak_repl_sup,
      riak_api_sup,
+     riak_admin_api_sup,
      riak_pipe_sup
     ].
 


### PR DESCRIPTION
Add `riak_admin_api_sup` to the list of top-level supervisors in riak_core_supps utility, for it to appear in the output of `riak_core_supps:q/1`.

This is a non-essential addition to the Riak Admin API (evolution of Riak Control) set of PRs (https://github.com/OpenRiak/riak/pull/35 and related).